### PR TITLE
[Bugfix] Screenshot diff Github Action fails for merge commits 

### DIFF
--- a/.github/diff_report/diff_screenshots.py
+++ b/.github/diff_report/diff_screenshots.py
@@ -2,9 +2,9 @@
 Utility to compare screenshots before and after a change and generate a report of the
 differences.
 
-Expected usage in a GitHub Actions workflow; compare `dev` with the `$BRANCH_NAME` in the
-associated PR that triggered the CI run:
-python src/seedsigner/resources/seedsigner-translations/.github/diff_report/diff_screenshots.py ./artifacts/dev ./artifacts/$BRANCH_NAME ./artifacts/diff
+Expected usage in a GitHub Actions workflow; compare `dev` with the `$INCOMING_CHANGES_REF` in the
+associated PR or merge that triggered the CI run:
+python src/seedsigner/resources/seedsigner-translations/.github/diff_report/diff_screenshots.py ./artifacts/dev ./artifacts/incoming ./artifacts/diff $INCOMING_CHANGES_REF
 """
 import argparse
 import glob
@@ -16,15 +16,16 @@ import shutil
 
 parser = argparse.ArgumentParser(prog=__name__)
 
-parser.add_argument("before_dir", type=str, help="Directory containing screenshots before the proposed changes")
-parser.add_argument("after_dir", type=str, help="Directory containing screenshots after the proposed changes")
+parser.add_argument("before_dir", type=str, help="Directory containing screenshots before the incoming changes")
+parser.add_argument("after_dir", type=str, help="Directory containing screenshots after the incoming changes")
 parser.add_argument("output_dir", type=str, help="Directory to save the screenshots diff report")
+parser.add_argument("incoming_changes_ref", type=str, help="Branch name or commit hash that contains the incoming changes")
 
 args = parser.parse_args()
 
-# "before" and "after" directories are named: artifacts/$TARGET_BRANCH and artifacts/$BRANCH_NAME
-before_branch_name = args.before_dir.split(os.path.sep)[-1]
-after_branch_name = args.after_dir.split(os.path.sep)[-1]
+# `before_dir` includes the branch name we'll be merging into
+baseline_branch = args.before_dir.split(os.path.sep)[-1]
+incoming_changes_ref = args.incoming_changes_ref
 
 def list_files_recursively(path: str) -> list[str]:
     """ Return a list of paths to all png files in the directory tree """
@@ -91,7 +92,7 @@ for file in list_files_recursively(args.after_dir):
 only_in_before = set(paths_before) - set(paths_after)
 
 html_content = "<h1>Screenshots diff report</h1>"
-html_content += f"""<p>Comparing {before_branch_name} to {after_branch_name}</p>"""
+html_content += f"""<p>Comparing {baseline_branch} to {incoming_changes_ref}</p>"""
 output_dir_before = os.path.join(args.output_dir, "before")
 output_dir_after = os.path.join(args.output_dir, "after")
 os.makedirs(output_dir_before, exist_ok=True)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      # head_ref: source branch name of a PR; null when action isn't a PR.
+      # sha: hash of a commit / merge.
+      INCOMING_CHANGES_REF: ${{ github.head_ref || github.sha }}
     steps:
       - name: Checkout main repo 'dev'
         uses: actions/checkout@v4
@@ -64,17 +66,17 @@ jobs:
       - name: Generate latest screenshots
         run: |
           rm -rf seedsigner-screenshots
-          mkdir -p artifacts/$BRANCH_NAME
+          mkdir -p artifacts/incoming
           python -m pytest tests/screenshot_generator/generator.py
           sleep 10
-          mv ./seedsigner-screenshots/* ./artifacts/$BRANCH_NAME/
+          mv ./seedsigner-screenshots/* ./artifacts/incoming/
       - name: Diff screenshots
         run: |
           mkdir -p artifacts/diff
-          python src/seedsigner/resources/seedsigner-translations/.github/diff_report/diff_screenshots.py ./artifacts/dev ./artifacts/$BRANCH_NAME ./artifacts/diff
+          python src/seedsigner/resources/seedsigner-translations/.github/diff_report/diff_screenshots.py ./artifacts/dev ./artifacts/incoming ./artifacts/diff $INCOMING_CHANGES_REF
       - name: Clean up artifacts
         run: |
-          rm -rf ./artifacts/$BRANCH_NAME
+          rm -rf ./artifacts/incoming
           rm -rf ./artifacts/dev
           mv ./artifacts/diff/* ./artifacts
           rmdir ./artifacts/diff


### PR DESCRIPTION
## The problem
Normally in a PR our screenshot diff Github Action's `$BRANCH_NAME` will be the proposer's incoming branch name (e.g. Keith wants to merge `kdmukai:my_new_feature` into `dev`; in this case `$BRANCH_NAME = my_new_feature`).

When the PR is merged into `dev`, the Action is triggered but now the `$BRANCH_NAME` ALSO ends up being `dev`. 

Now we end up with a conflict [when trying to move the new screenshots](https://github.com/SeedSigner/seedsigner-translations/blob/dev/.github/workflows/tests.yml#L70) to `./artifacts/$BRANCH_NAME` as we already wrote the baseline screenshots to `./artifacts/dev`.

See the error in this Action run: https://github.com/SeedSigner/seedsigner-translations/actions/runs/14741405238

## This PR
* Hard-code the new screenshots' output dir to `./artifacts/incoming` to further avoid any potential conflicts (a PR could try to merge `some_fork:dev` into `dev` which would create the same `./artifacts/dev` conflict otherwise).

* Alter the definition of `$BRANCH_NAME` (now renamed to `$INCOMING_CHANGES_REF`) to either be:
  * the incoming branch name if it's a PR (same as prior approach)
  * OR the commit hash if this is a PR merge.

  This change prevents us from trying to re-use the `dev` reference and, in the case of the above failed CI run, would have instead been `fbbf956`.

* Minor variable renaming for better clarity (e.g. `$BRANCH_NAME-> $INCOMING_CHANGES_REF` since it can now be a branch name or a commit hash).

* `$INCOMING_CHANGES_REF` is explicitly passed into the `diff_screenshots.py` call so it can be included in the html report.

---

## Testing
The updated action will run when this PR is created. A green check would mean that it at least did not break the main PR flow.

In a fork you can alter the rules for when this is run to have it trigger on any commit. This should enable you to test it in a side branch for the commit flow.
```
# Before
on:
  push:
    branches:
      - dev
      - main
  pull_request:

# After
on:
  push:
  pull_request:
```

See successful commit flow run in my test branch that includes the above minor change: https://github.com/kdmukai/seedsigner-translations/commit/8d6382f345160246c9fb499593a12da34590dca8

And another test commit that adds a new locale's translations: https://github.com/kdmukai/seedsigner-translations/commit/f7c51e8e22bbd03aa9981b2ff63fa1ba5c7511fa