### PR TITLE
update .gitignore to ignore mo binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .DS_Store
+
+# Only check in *.po files since *.mo
+# files can be generated from from them
+*.mo


### PR DESCRIPTION
Let me know if I can reword the comment better or remove the comment completely.

Let me know if I should delete `l10n/es/LC_MESSAGES/messages.mo` in this PR as well.

Ignores mo files in all subdirs as well.

```bash
$ echo "test" > test.mo
$ echo "test" > l10n/test.mo
$ git status
On branch mo-ignore
nothing to commit, working tree clean
```