### PR TITLE
ja update

### DIFF
--- a/l10n/ja/LC_MESSAGES/messages.po
+++ b/l10n/ja/LC_MESSAGES/messages.po
@@ -5,20 +5,20 @@
 # 
 # Translators:
 # Keith Mukai, 2022
-# mister wizard, 2025
-# I M, 2025
+# mister wizard, 2026
+# I M, 2026
 # 
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: seedsigner 0.8.5-rc1\n"
+"Project-Id-Version: seedsigner 0.8.6\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-01-28 13:28-0600\n"
+"POT-Creation-Date: 2025-12-26 07:32-0600\n"
 "PO-Revision-Date: 2022-04-29 13:50+0000\n"
-"Last-Translator: I M, 2025\n"
+"Last-Translator: I M, 2026\n"
 "Language-Team: Japanese (https://app.transifex.com/seedsigner/teams/135832/ja/)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.16.0\n"
 "Language: ja\n"
@@ -32,7 +32,7 @@ msgstr "tBtc"
 #. Testnet sats
 #: src/seedsigner/gui/components.py
 msgid "tSats"
-msgstr "tサトシ"
+msgstr "tｻﾄｼ"
 
 #: src/seedsigner/gui/components.py src/seedsigner/gui/screens/psbt_screens.py
 msgid "btc"
@@ -41,52 +41,52 @@ msgstr "btc"
 #: src/seedsigner/gui/components.py src/seedsigner/gui/screens/psbt_screens.py
 #: src/seedsigner/models/settings_definition.py
 msgid "sats"
-msgstr "サトシ"
+msgstr "ｻﾄｼ"
 
 #: src/seedsigner/gui/toast.py
 msgid ""
 "You can remove\n"
 "the SD card now"
-msgstr "SDカードを抜いても良い"
+msgstr "SDｶｰﾄﾞを抜いても良い"
 
 #: src/seedsigner/gui/toast.py
 msgid "SD card removed"
-msgstr "SDカードを抜いた状態"
+msgstr "SDｶｰﾄﾞが抜かれました"
 
 #: src/seedsigner/gui/toast.py
 msgid "SD card inserted"
-msgstr "SDカードを挿入した状態"
+msgstr "SDｶｰﾄﾞが挿入されました"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Review PSBT"
-msgstr "PSBTの内容を確認する"
+msgid "Review Transaction"
+msgstr "取引を確認"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Review Details"
-msgstr "詳細を確認する"
+msgid "Review details"
+msgstr "詳細を確認"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "1 input"
-msgstr "インプット数 = 1"
+msgstr "ｲﾝﾌﾟｯﾄ数 = 1"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "input 1"
-msgstr "インプット1"
+msgstr "ｲﾝﾌﾟｯﾄ1"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "input 2"
-msgstr "インプット2"
+msgstr "ｲﾝﾌﾟｯﾄ2"
 
 #. Indicates that items have been omitted from a series: e.g. "1, 2, 3, [...],
 #. 8"
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "[ ... ]"
-msgstr " ... "
+msgstr "[ ... ]"
 
 #. Input number will be inserted (e.g. "input 3")
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "input {}"
-msgstr "インプット {}"
+msgstr "ｲﾝﾌﾟｯﾄ {}"
 
 #. Ellipsis ("...") characters used to truncate an address (e.g. "bc1qabc...")
 #: src/seedsigner/gui/screens/psbt_screens.py
@@ -124,17 +124,17 @@ msgid "change"
 msgstr "お釣り"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "PSBT Math"
-msgstr "PSBT計算"
+msgid "Transaction Math"
+msgstr "取引明細"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Review Recipients"
-msgstr "送金先を確認する"
+msgid "Review recipients"
+msgstr "送金先を確認"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "input"
 msgid_plural "inputs"
-msgstr[0] "インプット"
+msgstr[0] "ｲﾝﾌﾟｯﾄ"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "recipient"
@@ -144,39 +144,41 @@ msgstr[0] "送金先"
 #. Denonination is inserted (e.g. your "btc change" or "sats change")
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "{} change"
-msgstr "{}単位でのお釣り"
+msgstr "{}のお釣り"
 
+#. Describes the address type (change or receive)
 #: src/seedsigner/gui/screens/psbt_screens.py
-#: src/seedsigner/models/settings_definition.py
-#: src/seedsigner/views/seed_views.py
-msgid "Multisig"
-msgstr "マルチシグ"
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "change address"
+msgstr "お釣り用ｱﾄﾞﾚｽ"
 
+#. Describes the address type (change or receive)
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Change"
-msgstr "お釣り"
+#: src/seedsigner/gui/screens/seed_screens.py
+msgid "receive address"
+msgstr "入金用ｱﾄﾞﾚｽ"
 
-#. Abbreviation for receive address
+#. Symbol for index number, e.g. "address #3"
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Addr"
-msgstr "アドレス"
+msgid "#"
+msgstr "#"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "Address verified!"
-msgstr "アドレスを確認済み。"
+msgstr "ｱﾄﾞﾚｽを確認済み。"
 
 #. Shown when displaying OP_RETURN as non-human-readable hexadecimal data
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "raw hex data"
-msgstr "生の16進法データ"
+msgstr "生の16進法ﾃﾞｰﾀ"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
-msgid "Sign PSBT"
-msgstr "PSBTに署名する"
+msgid "Sign Transaction"
+msgstr "取引を署名"
 
 #: src/seedsigner/gui/screens/psbt_screens.py
 msgid "Click to approve this transaction"
-msgstr "クリックで取り引きを認可する"
+msgstr "ｸﾘｯｸで取り引きを認可"
 
 #: src/seedsigner/gui/screens/scan_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
@@ -219,8 +221,8 @@ msgid "Privacy Leak!"
 msgstr "個人情報漏洩注意！"
 
 #: src/seedsigner/gui/screens/screen.py
-msgid "I Understand"
-msgstr "承知しました。"
+msgid "I understand"
+msgstr "承知しました"
 
 #: src/seedsigner/gui/screens/screen.py
 msgid "Classified Info!"
@@ -229,7 +231,7 @@ msgstr "秘密情報！"
 #: src/seedsigner/gui/screens/screen.py src/seedsigner/views/scan_views.py
 #: src/seedsigner/views/view.py
 msgid "Error"
-msgstr "エラー"
+msgstr "ｴﾗｰ"
 
 #: src/seedsigner/gui/screens/screen.py
 msgid "Restarting"
@@ -241,17 +243,9 @@ msgid ""
 "\n"
 "All in-memory data will be wiped."
 msgstr ""
-"シードサイナーが再起動中。\n"
+"ｼｰﾄﾞｻｲﾅｰが再起動中。\n"
 "\n"
-"揮発性メモリーにある全てのデータが削除されます。"
-
-#: src/seedsigner/gui/screens/screen.py
-msgid "Powering Off"
-msgstr "ｼｬｯﾄﾀﾞｳﾝ中"
-
-#: src/seedsigner/gui/screens/screen.py
-msgid "Please wait about 30 seconds before disconnecting power."
-msgstr "電源を抜く前に、約30秒待ってください。"
+"揮発性ﾒﾓﾘｰにある全てのﾃﾞｰﾀが削除されます。"
 
 #: src/seedsigner/gui/screens/screen.py
 msgid "Just Unplug It"
@@ -263,71 +257,61 @@ msgstr "いつでも電源を抜いても宜しい。"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Finalize Seed"
-msgstr "シードを確定する"
+msgstr "ｼｰﾄﾞを確定"
 
 #. a label for the shortened Key-id of a BIP-32 master HD wallet
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
 #: src/seedsigner/views/seed_views.py
 msgid "fingerprint"
-msgstr "フィンガープリント値"
-
-#: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/seed_views.py
-msgid "Backup Seed"
-msgstr "シードをバックアップする"
-
-#. Additional explainer for the two seed backup options (mnemonic phrase and
-#. SeedQR).
-#: src/seedsigner/gui/screens/seed_screens.py
-msgid "Backups do not include your passphrase."
-msgstr "バックアップはパスフレーズを含みません。パスフレーズを追加した場合、別途に保存する必要があります。"
+msgstr "ﾌｨﾝｶﾞｰﾌﾟﾘﾝﾄ値"
 
 #. Displays the page number and total: (e.g. page 1 of 6)
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Seed Words: {}/{}"
-msgstr "シードワード： {}/{}"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞ： {}/{}"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "BIP-85 Index"
-msgstr "BIP-85インデックス"
+msgstr "BIP-85ｲﾝﾃﾞｯｸｽ"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Verify Backup?"
-msgstr "バックアップを確認しますか？"
+msgstr "ﾊﾞｯｸｱｯﾌﾟを確認しますか？"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Optionally verify that your mnemonic backup is correct."
-msgstr "バックアップに誤りがないかを確認する（省略可）。"
+msgstr "ﾊﾞｯｸｱｯﾌﾟに誤りがないかを確認する（省略可）。"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Derivation Path"
-msgstr "導出パス"
+msgstr "導出ﾊﾟｽ"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/views/seed_views.py
-msgid "Export Xpub"
-msgstr "xpubをエクスポートする"
+msgid "Export xpub"
+msgstr ""
+" \n"
+"xpubをｴｸｽﾎﾟｰﾄ"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Xpub Details"
 msgstr "xpubの詳細"
 
-#. Short for "BIP32 Master Fingerprint"
+#. Short for "BIP-32 Master Fingerprint"
 #. a label for the shortened Key-id of a BIP-32 master HD wallet
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Fingerprint"
-msgstr "フィンガープリント値"
+msgstr "ﾌｨﾝｶﾞｰﾌﾟﾘﾝﾄ値"
 
 #. Short for "Derivation Path"
 #. a label for the derivation-path into a BIP-32 HD wallet
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Derivation"
-msgstr "導出パス"
+msgstr "導出ﾊﾟｽ"
 
-#. Short for "BIP32 Extended Public Key"
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Xpub"
 msgstr "xpub"
@@ -336,17 +320,17 @@ msgstr "xpub"
 #: src/seedsigner/models/settings_definition.py
 #: src/seedsigner/views/seed_views.py
 msgid "BIP-39 Passphrase"
-msgstr "BIP-39パスフレーズ"
+msgstr "BIP-39ﾊﾟｽﾌﾚｰｽﾞ"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Verify Passphrase"
-msgstr "パスフレーズを確認する"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを確認"
 
 #. Describes the effect of applying a BIP-39 passphrase; it changes the seed's
 #. fingerprint
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "changes fingerprint"
-msgstr "フィンガープリント値が変わる"
+msgstr "ﾌｨﾝｶﾞｰﾌﾟﾘﾝﾄ値が変わる"
 
 #. Refers to the SeedQR type: Standard or Compact
 #: src/seedsigner/gui/screens/seed_screens.py
@@ -356,21 +340,21 @@ msgstr "標準"
 #. Briefly explains the Standard SeedQR data format
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "BIP-39 wordlist indices"
-msgstr "BIP-39のワードリストで何番目のワード"
+msgstr "BIP-39のﾜｰﾄﾞﾘｽﾄで何番目のﾜｰﾄﾞ"
 
 #. Refers to the SeedQR type: Standard or Compact
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Compact"
-msgstr "コンパクト"
+msgstr "ｺﾝﾊﾟｸﾄ"
 
 #. Briefly explains the Compact SeedQR data format
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Raw entropy bits"
-msgstr "エントロピーの生データ"
+msgstr "ｴﾝﾄﾛﾋﾟｰの生ﾃﾞｰﾀ"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Transcribe SeedQR"
-msgstr "シードQRの控えを書き写す"
+msgstr "ｼｰﾄﾞQRの控えを書き写す"
 
 #. Refers to the QR code size: 21x21, 25x25, or 29x29
 #: src/seedsigner/gui/screens/seed_screens.py
@@ -379,53 +363,42 @@ msgstr "{}x{} 開始"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "click to exit"
-msgstr "クリックして前の画面に戻る"
+msgstr "ｸﾘｯｸして前の画面に戻る"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid ""
 "Optionally scan your transcribed SeedQR to confirm that it reads back "
 "correctly."
-msgstr "書き写されたシードQRの控えを読み取り、誤りがないかを確認する（省略可）。"
+msgstr "書き写されたｼｰﾄﾞQRの控えを読み取り、誤りがないかを確認する（省略可）。"
 
 #: src/seedsigner/gui/screens/seed_screens.py
-#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+#: src/seedsigner/views/seed_views.py
 msgid "Verify Address"
-msgstr "アドレスを確認する"
+msgstr "ｱﾄﾞﾚｽを確認"
 
 #. Inserts the nth address number (e.g. "Checking address 7")
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Checking address {}"
-msgstr "{}番目のアドレスを確認中"
+msgstr "{}番目のｱﾄﾞﾚｽを確認中"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Address Verified"
-msgstr "アドレス確認済み"
-
-#. Describes the address type (change or receive)
-#: src/seedsigner/gui/screens/seed_screens.py
-msgid "change address"
-msgstr "お釣り用アドレス"
-
-#. Describes the address type (change or receive)
-#: src/seedsigner/gui/screens/seed_screens.py
-msgid "receive address"
-msgstr "入金用アドレス"
+msgstr "ｱﾄﾞﾚｽ確認済み"
 
 #. Describes the address index (e.g. "index 7")
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "index {}"
-msgstr "インデックス{}"
+msgstr "ｲﾝﾃﾞｯｸｽ{}"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Multisig Verification"
-msgstr "マルチシグの確認"
+msgstr "ﾏﾙﾁｼｸﾞの確認"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid ""
 "Load your multisig wallet descriptor to verify your receive/self-transfer or"
 " change address."
-msgstr ""
-"マルチシグウォレットのdescriptorを入力すれば、自分の入金用アドレス（自分に送金する場合も含む）や自分のお釣り用アドレスを確認できる。"
+msgstr "ﾏﾙﾁｼｸﾞｳｫﾚｯﾄのdescriptorを入力すれば、お釣り用ｱﾄﾞﾚｽ（或いは自分に送金する場合の入金用ｱﾄﾞﾚｽ）を確認できる。"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Descriptor Loaded"
@@ -442,7 +415,7 @@ msgstr "署名用鍵"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Review Message"
-msgstr "メッセージを確認する"
+msgstr "ﾒｯｾｰｼﾞを確認する"
 
 #. Short for "Next step"
 #: src/seedsigner/gui/screens/seed_screens.py
@@ -453,16 +426,16 @@ msgstr "次"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "Confirm Address"
-msgstr "アドレスを確認する"
+msgstr "ｱﾄﾞﾚｽを確認"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 #: src/seedsigner/views/seed_views.py
-msgid "Sign Message"
-msgstr "メッセージを署名する"
+msgid "Sign message"
+msgstr "ﾒｯｾｰｼﾞを署名"
 
 #: src/seedsigner/gui/screens/seed_screens.py
 msgid "derivation path"
-msgstr "導出パス"
+msgstr "導出ﾊﾟｽ"
 
 #: src/seedsigner/gui/screens/settings_screens.py
 #: src/seedsigner/views/settings_views.py src/seedsigner/views/view.py
@@ -473,7 +446,7 @@ msgstr "設定"
 #. working properly
 #: src/seedsigner/gui/screens/settings_screens.py
 msgid "I/O Test"
-msgstr "入出力テスト"
+msgstr "入出力ﾃｽﾄ"
 
 #. Blank the screen
 #: src/seedsigner/gui/screens/settings_screens.py
@@ -524,7 +497,7 @@ msgstr "メニュー"
 
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "click a button"
-msgstr "ボタン押し待ち"
+msgstr "ﾎﾞﾀﾝを押す"
 
 #. A prompt to the user to either accept or reshoot the image
 #: src/seedsigner/gui/screens/tools_screens.py
@@ -539,12 +512,12 @@ msgstr "使用する"
 #. current roll number vs total rolls (e.g. roll 7 of 50)
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Dice Roll {}/{}"
-msgstr "{}/{}回目のサイコロを投げます"
+msgstr "{}/{}回目のｻｲｺﾛを投げる"
 
 #. Build the last word in a 12 or 24 word BIP-39 mnemonic seed phrase.
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Build Final Word"
-msgstr "最後のワードを決める"
+msgstr "最後のﾜｰﾄﾞを決める"
 
 #. Final word calc. `mnemonic_length` = 12 or 24. `num_bits` = 7 or 3 (bits of
 #. entropy in final word).
@@ -552,12 +525,13 @@ msgstr "最後のワードを決める"
 msgid ""
 "The {mnemonic_length}th word is built from {num_bits} more entropy bits plus"
 " auto-calculated checksum."
-msgstr "{mnemonic_length}番目のワードを、更なる{num_bits}ビットのエントロピーと、自動計算されるチェックサムとで組む。"
+msgstr ""
+"{mnemonic_length}番目のﾜｰﾄﾞを、更なる{num_bits}ﾋﾞｯﾄのｴﾝﾄﾛﾋﾟｰと、自動計算されるﾁｪｯｸｻﾑとで組む。 "
 
 #. current coin-flip number vs total flips (e.g. flip 3 of 4)
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Coin Flip {}/{}"
-msgstr "{}/{}のコインを投げる"
+msgstr "{}/{}のｺｲﾝを投げる"
 
 #. How we call the "front" side result during a coin toss.
 #: src/seedsigner/gui/screens/tools_screens.py
@@ -577,33 +551,38 @@ msgstr "現在の入力＝「{}」"
 #. A function of "x" to be used for detecting errors in "x"
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Checksum"
-msgstr "チェックサム"
+msgstr "ﾁｪｯｸｻﾑ"
 
 #. labeled presentation of the last word in a BIP-39 mnemonic seed phrase.
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Final Word: \"{}\""
-msgstr "最後のワード＝「{}」"
+msgstr "最後のﾜｰﾄﾞ＝「{}」"
 
 #. a label for the last word of a 12-word BIP-39 mnemonic seed phrase
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "12th Word"
-msgstr "12番目のワード"
+msgstr "12番目のﾜｰﾄﾞ"
 
 #. a label for the last word of a 24-word BIP-39 mnemonic seed phrase
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "24th Word"
-msgstr "24番目のワード"
+msgstr "24番目のﾜｰﾄﾞ"
 
 #. a label for the tool to explore public addresses for this seed.
 #: src/seedsigner/gui/screens/tools_screens.py
 #: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
 msgid "Address Explorer"
-msgstr "アドレス・エクスプローラー"
+msgstr "ｱﾄﾞﾚｽ･ｴｸｽﾌﾟﾛｰﾗｰ"
 
 #. a label for a BIP-380-ish Output Descriptor
 #: src/seedsigner/gui/screens/tools_screens.py
 msgid "Wallet descriptor"
-msgstr "ウォレットのdescriptor"
+msgstr "ｳｫﾚｯﾄのdescriptor"
+
+#. Insert the number of addrs displayed per screen (e.g. "Next 10")
+#: src/seedsigner/gui/screens/tools_screens.py
+msgid "Next {}"
+msgstr "次の{}"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Enabled"
@@ -631,7 +610,7 @@ msgstr "0.01で切り替える"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "BTC | sats hybrid"
-msgstr "BTC・サトシの混合表示"
+msgstr "BTC・ｻﾄｼの混合表示"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "0°"
@@ -666,28 +645,33 @@ msgstr "高"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Mainnet"
-msgstr "メインネット"
+msgstr "ﾒｲﾝﾈｯﾄ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Testnet"
-msgstr "テストネット"
+msgstr "ﾃｽﾄﾈｯﾄ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Regtest"
-msgstr "リグレッションテスト"
+msgstr "ﾘｸﾞﾚｯｼｮﾝﾃｽﾄ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Store Settings on SD card"
-msgstr "設定をSDカードに保存する"
+msgstr "設定をSDｶｰﾄﾞに保存する"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Insert SD card to enable"
-msgstr "SDカードを挿入すれば、できるようになる"
+msgstr "SDｶｰﾄﾞを挿入して有効化"
 
 #: src/seedsigner/models/settings_definition.py
 #: src/seedsigner/views/seed_views.py
 msgid "Single Sig"
-msgstr "シングルシグ"
+msgstr "ｼﾝｸﾞﾙｼｸﾞ"
+
+#: src/seedsigner/models/settings_definition.py
+#: src/seedsigner/views/seed_views.py
+msgid "Multisig"
+msgstr "ﾏﾙﾁｼｸﾞ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Native Segwit"
@@ -707,9 +691,9 @@ msgstr "Taproot"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Custom Derivation"
-msgstr "都度指定の導出パス"
+msgstr "都度指定の導出ﾊﾟｽ"
 
-#. Terminology used by Electrum seeds; equivalent to bip39 passphrase
+#. Terminology used by Electrum seeds; equivalent to BIP-39 passphrase
 #: src/seedsigner/models/settings_definition.py
 msgid "Custom Extension"
 msgstr "都度指定の拡張子"
@@ -720,7 +704,7 @@ msgstr "言語"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Mnemonic language"
-msgstr "シードワード言語"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞ言語"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Persistent settings"
@@ -728,7 +712,7 @@ msgstr "非揮発性設定"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Coordinator software"
-msgstr "コーディネーター用アプリ"
+msgstr "ｺｰﾃﾞｨﾈｰﾀｰ用ｱﾌﾟﾘ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Denomination display"
@@ -736,15 +720,15 @@ msgstr "表示金額の単位"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Bitcoin network"
-msgstr "ビットコインネットワーク"
+msgstr "ﾋﾞｯﾄｺｲﾝﾈｯﾄﾜｰｸ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "QR code density"
-msgstr "QRコードの解像度"
+msgstr "QRｺｰﾄﾞの解像度"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Xpub export"
-msgstr "xpubをエクスポートする"
+msgstr "xpubのｴｸｽﾎﾟｰﾄ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Sig types"
@@ -752,7 +736,7 @@ msgstr "署名の書類"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Script types"
-msgstr "スクリプトの種類"
+msgstr "ｽｸﾘﾌﾟﾄの種類"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Show xpub details"
@@ -760,23 +744,23 @@ msgstr "xpubの詳細を表示"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "BIP-39 passphrase"
-msgstr "BIP-39パスフレーズ"
+msgstr "BIP-39ﾊﾟｽﾌﾚｰｽﾞ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Camera rotation"
-msgstr "カメラ回転"
+msgstr "ｶﾒﾗ回転"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Compact SeedQR"
-msgstr "コンパクトなシードQR"
+msgstr "ｺﾝﾊﾟｸﾄなｼｰﾄﾞQR"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "BIP-85 child seeds"
-msgstr "BIP-85の子シード"
+msgstr "BIP-85の子ｼｰﾄﾞ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Electrum seeds"
-msgstr "Electrum用シード"
+msgstr "Electrum用ｼｰﾄﾞ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Native Segwit only"
@@ -784,7 +768,7 @@ msgstr "Native Segwitのみ"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Message signing"
-msgstr "メッセージの署名"
+msgstr "ﾒｯｾｰｼﾞの署名"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Show privacy warnings"
@@ -796,11 +780,22 @@ msgstr "深刻危険注意の表示"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Show QR brightness tips"
-msgstr "QR輝度ヒントの表示"
+msgstr "QR輝度ﾋﾝﾄの表示"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "Show partner logos"
-msgstr "パートナー ロゴの表示"
+msgstr "ﾊﾟｰﾄﾅｰ ﾛｺﾞの表示"
+
+#. Hardware settings option to specify the screen driver (e.g. st7789 vs
+#. ili9341)
+#: src/seedsigner/models/settings_definition.py
+msgid "Display type"
+msgstr "ﾃﾞｨｽﾌﾟﾚｲの種類"
+
+#. Hardware settings option to invert how the screen driver displays colors.
+#: src/seedsigner/models/settings_definition.py
+msgid "Invert colors"
+msgstr "色の反転"
 
 #: src/seedsigner/models/settings_definition.py
 msgid "QR background color"
@@ -809,22 +804,22 @@ msgstr "QR背景色"
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
 #: src/seedsigner/views/tools_views.py
 msgid "Scan a seed"
-msgstr "シードを読み取る"
+msgstr "ｼｰﾄﾞを読み取る"
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
 #: src/seedsigner/views/tools_views.py
 msgid "Enter 12-word seed"
-msgstr "12ワードのシードを記入する"
+msgstr "12ﾜｰﾄﾞのｼｰﾄﾞを記入"
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
 #: src/seedsigner/views/tools_views.py
 msgid "Enter 24-word seed"
-msgstr "24ワードのシードを記入する"
+msgstr "24ﾜｰﾄﾞのｼｰﾄﾞを記入"
 
 #: src/seedsigner/views/psbt_views.py src/seedsigner/views/seed_views.py
 #: src/seedsigner/views/tools_views.py
 msgid "Enter Electrum seed"
-msgstr "Electrum用シードを記入する"
+msgstr "Electrum用ｼｰﾄﾞを記入"
 
 #. Inserts fingerprint w/"?" to indicate that this seed can't sign the current
 #. PSBT
@@ -834,7 +829,7 @@ msgstr "{} (?)"
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Select Signer"
-msgstr "署名者を選択する"
+msgstr "署名者を選択"
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Parsing PSBT..."
@@ -842,14 +837,15 @@ msgstr "PSBTを解読中..."
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Unsupported Script Type!"
-msgstr "未対応のスクリプトの種類！"
+msgstr "未対応のｽｸﾘﾌﾟﾄの種類！"
 
 #: src/seedsigner/views/psbt_views.py
 msgid ""
-"PSBT has unsupported input script type, please verify your change addresses."
-msgstr "PSBTに未対応のスクリプトの種類があります。お釣り用アドレスをご確認ください。"
+"Transaction has unsupported input script type, please verify your change "
+"addresses."
+msgstr "取引のｲﾝﾌﾟｯﾄに未対応のｽｸﾘﾌﾟﾄがあるため、お釣り用ｱﾄﾞﾚｽを手動で確認する必要がある。"
 
-#: src/seedsigner/views/psbt_views.py
+#: src/seedsigner/views/psbt_views.py src/seedsigner/views/view.py
 msgid "Continue"
 msgstr "続く"
 
@@ -861,9 +857,9 @@ msgstr "全額が支払われるぞ！"
 
 #: src/seedsigner/views/psbt_views.py
 msgid ""
-"This PSBT spends its entire input value. No change is coming back to your "
-"wallet."
-msgstr "このPSBTのインプットの全額が支払われるため、送金元のウォレットへお釣りが一切戻って来ません。"
+"This transaction spends its entire input value. No change is coming back to "
+"your wallet."
+msgstr "ｲﾝﾌﾟｯﾄの全額が支払われるため、お釣りはありません。"
 
 #. Future-tense used to indicate that this transaction will send this amount,
 #. as opposed to "Send" on its own which could be misread as an instant
@@ -874,16 +870,16 @@ msgid "Will Send"
 msgstr "送付する予定"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Next Recipient"
+msgid "Next recipient"
 msgstr "次の送金先"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Skip Verification"
-msgstr "確認を省略"
+msgid "Skip verification"
+msgstr "確認ステップを省略"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Verify Multisig Change"
-msgstr "マルチシグのお釣りを確認する"
+msgid "Verify multisig change"
+msgstr "ﾏﾙﾁｼｸﾞのお釣りを確認"
 
 #. The amount you're receiving back from the transaction
 #: src/seedsigner/views/psbt_views.py
@@ -895,8 +891,8 @@ msgid "Self-Transfer"
 msgstr "自分に送金"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Verify Multisig Addr"
-msgstr "マルチシグアドレスを確認する"
+msgid "Verify multisig addr"
+msgstr "ﾏﾙﾁｼｸﾞのｱﾄﾞﾚｽを確認"
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Verifying Change..."
@@ -908,37 +904,37 @@ msgstr "自分への送金を確認中..."
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
-msgid "PSBT's {} address could not be verified from wallet descriptor."
-msgstr "ウォレットのdescriptorからPSBTの{}のアドレスを確認できなかった！"
+msgid "Transaction's {} address could not be verified from wallet descriptor."
+msgstr "ｳｫﾚｯﾄのdescriptorから、取引の{}のｱﾄﾞﾚｽを確認できなかった。"
 
 #. Variable is either "change" or "self-transfer".
 #: src/seedsigner/views/psbt_views.py
-msgid "PSBT's {} address could not be generated from your seed."
-msgstr "シードからPSBTの{}のアドレスを生成できなかった！"
+msgid "Transaction's {} address could not be generated from your seed."
+msgstr "読み込まれたｼｰﾄﾞから、取引の{}のｱﾄﾞﾚｽを生成できなかった。"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Suspicious PSBT"
-msgstr "怪しいPSBT！"
+msgid "Suspicious Transaction"
+msgstr "怪しい取引"
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Address Verification Failed"
-msgstr "アドレスを確認できなかった！"
+msgstr "ｱﾄﾞﾚｽを確認できなかった！"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Discard PSBT"
-msgstr "PSBTを破棄する"
+msgid "Discard transaction"
+msgstr "取引を破棄"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Approve PSBT"
-msgstr "PSBTを承認する"
+msgid "Approve transaction"
+msgstr "取り引きを認可"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "Select Diff Seed"
-msgstr "違うシードを選択"
+msgid "Select different seed"
+msgstr "違うｼｰﾄﾞを選択"
 
 #: src/seedsigner/views/psbt_views.py
-msgid "PSBT Error"
-msgstr "PSBTのエラーが発生した！"
+msgid "Transaction Error"
+msgstr "取引ｴﾗｰ！"
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Signing Failed"
@@ -946,7 +942,7 @@ msgstr "署名できなかった！"
 
 #: src/seedsigner/views/psbt_views.py
 msgid "Signing with this seed did not add a valid signature."
-msgstr "このシードで署名しても、有効な署名を付加できなかった！"
+msgstr "このｼｰﾄﾞで署名しても、有効な署名を付加できなかった！"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Scan a QR code"
@@ -960,37 +956,37 @@ msgstr "認知不可能か未対応のQRです。"
 msgid "Wrong QR Type"
 msgstr "QRの種類が違う"
 
-#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
-msgid "Scan PSBT"
-msgstr "PSBTを読み取る"
+#: src/seedsigner/views/scan_views.py
+msgid "Scan Transaction"
+msgstr "取引を読み取る"
 
 #: src/seedsigner/views/scan_views.py
-msgid "Expected a PSBT"
-msgstr "PSBT用QRを期待していたところ、内容が違う"
+msgid "Expected a transaction"
+msgstr "取引を期待していたところ、内容が違う"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Scan SeedQR"
-msgstr "シードQRを読み取る"
+msgstr "ｼｰﾄﾞQRを読み取る"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Expected a SeedQR"
-msgstr "シードQRを期待していたところ、内容が違う"
+msgstr "ｼｰﾄﾞQRが必要です"
 
-#: src/seedsigner/views/scan_views.py
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
 msgid "Scan descriptor"
 msgstr "descriptorを読み取る"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Expected a wallet descriptor QR"
-msgstr "ウォレットdescriptor用QRを期待していたところ、内容が違う"
+msgstr "ｳｫﾚｯﾄdescriptorが必要です"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Scan address QR"
-msgstr "アドレス用QRを読み取る"
+msgstr "ｱﾄﾞﾚｽ用QRを読み取る"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Expected an address QR"
-msgstr "アドレス用QRを期待していたところ、内容が違う"
+msgstr "ｱﾄﾞﾚｽ用QRが必要です"
 
 #: src/seedsigner/views/scan_views.py
 msgid "Unknown QR Type"
@@ -1000,10 +996,9 @@ msgstr "不明な種類のQR"
 msgid "QRCode is invalid or is a data format not yet supported."
 msgstr "無効か未対応形式のQRです。"
 
-#: src/seedsigner/views/scan_views.py src/seedsigner/views/seed_views.py
-#: src/seedsigner/views/view.py
-msgid "Done"
-msgstr "終了"
+#: src/seedsigner/views/scan_views.py src/seedsigner/views/view.py
+msgid "Back to Main Menu"
+msgstr "メニューへ戻る"
 
 #. This is on the opening splash screen, displayed above the HRF logo
 #: src/seedsigner/views/screensaver.py
@@ -1012,47 +1007,51 @@ msgstr "下記からの支援に感謝を"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Load a seed"
-msgstr "シードを入力"
+msgstr "ｼｰﾄﾞを入力"
 
 #: src/seedsigner/views/seed_views.py
 msgid "In-Memory Seeds"
-msgstr "揮発性メモリー内のシード"
+msgstr "揮発性ﾒﾓﾘｰ内のｼｰﾄﾞ"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Load the seed to verify"
-msgstr "シードを入力して確認する"
+msgstr "ｼｰﾄﾞを入力して確認する"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Select seed to verify"
-msgstr "シードを選択して確認する"
+msgstr "ｼｰﾄﾞを選択して確認する"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Sign Message"
+msgstr "ﾒｯｾｰｼﾞを署名する"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Load the seed to sign with"
-msgstr "署名するためのシードを入力"
+msgstr "署名するためのｼｰﾄﾞを入力"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Select seed to sign with"
-msgstr "署名するためのシードを選択する"
+msgstr "署名するためのｼｰﾄﾞを選択する"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Scan a SeedQR"
-msgstr "シードQRを読み取る"
+msgstr "ｼｰﾄﾞQRを読み取る"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Create a seed"
-msgstr "シードを作る"
+msgstr "ｼｰﾄﾞを作る"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Load A Seed"
+msgid "Load a Seed"
 msgstr "シードを読み込む"
 
 #. Inserts the word number (e.g. "Seed Word #6")
 #: src/seedsigner/views/seed_views.py
 msgid "Seed Word #{}"
-msgstr "{}番目のシードワード"
+msgstr "{}番目のｼｰﾄﾞﾜｰﾄﾞ"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Review & Edit"
+msgid "Review & edit"
 msgstr "確認・編集"
 
 #: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
@@ -1061,68 +1060,100 @@ msgstr "破棄"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Invalid Mnemonic!"
-msgstr "シードが無効です！"
+msgstr "ｼｰﾄﾞが無効です！"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Checksum failure; not a valid seed phrase."
-msgstr "チェックサム整合性無し、シードが無効です！"
+msgstr "ﾁｪｯｸｻﾑ整合性無し、ｼｰﾄﾞが無効です！"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Done"
+msgstr "終了"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Edit passphrase"
-msgstr "パスフレーズを編集する"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを編集する"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Discard passphrase"
-msgstr "パスフレーズを破棄する"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを破棄する"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Skip passphrase"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞ入力を省略"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Discard passphrase?"
-msgstr "パスフレーズを破棄する？"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞを破棄する？"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Your current passphrase entry will be erased"
-msgstr "現在記入中のパスフレーズが消去される"
+msgid "Your current passphrase entry will be erased."
+msgstr "現在記入中のﾊﾟｽﾌﾚｰｽﾞが消去される。"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Keep Seed"
+msgid "Skip passphrase?"
+msgstr "ﾊﾟｽﾌﾚｰｽﾞ入力を省略する？"
+
+#: src/seedsigner/views/seed_views.py
+msgid "You have not entered a passphrase yet."
+msgstr "ﾊﾟｽﾌﾚｰｽﾞをまだ入力されていない。"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Keep seed"
 msgstr "シードを保管"
 
 #. Inserts the seed fingerprint
 #: src/seedsigner/views/seed_views.py
 msgid "Wipe seed {} from the device?"
-msgstr "シード{}を消去する？"
+msgstr "ｼｰﾄﾞ{}を消去する？"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Discard Seed?"
-msgstr "シードを破棄する？"
+msgstr "ｼｰﾄﾞを破棄する？"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Electrum warning"
+msgid "Electrum Warning"
 msgstr "Electrumに関する注意"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Some features are disabled for Electrum seeds."
-msgstr "Electrum用シードの場合、使えない機能もあることにご注意ください。"
+msgstr "Electrum用ｼｰﾄﾞの場合、使えない機能もあることにご注意ください。"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Verify Addr"
-msgstr "アドレスを確認する"
+msgid "Scan transaction"
+msgstr "取引を読み取る"
+
+#: src/seedsigner/views/seed_views.py src/seedsigner/views/tools_views.py
+msgid "Address explorer"
+msgstr "ｱﾄﾞﾚｽ･ｴｸｽﾌﾟﾛｰﾗｰ"
 
 #: src/seedsigner/views/seed_views.py
-msgid "BIP-85 Child Seed"
-msgstr "BIP-85の子シード"
+msgid "Backup seed"
+msgstr "ｼｰﾄﾞをﾊﾞｯｸｱｯﾌﾟ"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Discard Seed"
-msgstr "シードを破棄"
+msgid "BIP-85 child seed"
+msgstr "BIP-85の子ｼｰﾄﾞ"
 
 #: src/seedsigner/views/seed_views.py
-msgid "View Seed Words"
-msgstr "シードワードを表示"
+msgid "Discard seed"
+msgstr "ｼｰﾄﾞを破棄"
+
+#: src/seedsigner/views/seed_views.py
+msgid "View seed words"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞを表示"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Export as SeedQR"
-msgstr "シードQRとしてエクスポート"
+msgstr "ｼｰﾄﾞQRとしてｴｸｽﾎﾟｰﾄ"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Backup Seed"
+msgstr "ｼｰﾄﾞをﾊﾞｯｸｱｯﾌﾟする"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Export Xpub"
+msgstr "xpubをｴｸｽﾎﾟｰﾄする"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Xpub can be used to view all future transactions."
@@ -1134,7 +1165,7 @@ msgstr "xpub生成中..."
 
 #: src/seedsigner/views/seed_views.py
 msgid "You must keep your seed words private & away from all online devices."
-msgstr "シードワードを秘密に守り、インターネットに接続可能な機器等に保管しないよう、ご注意ください！"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞを秘密に守り、ｲﾝﾀｰﾈｯﾄに接続可能な機器等に保管しないよう、ご注意ください！"
 
 #. Inserts the child index (e.g. "Child #0")
 #: src/seedsigner/views/seed_views.py
@@ -1143,34 +1174,34 @@ msgstr "子#{}"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Seed Words"
-msgstr "シードワード"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞ"
 
 #: src/seedsigner/views/seed_views.py
 msgid "12 Words"
-msgstr "12ワード"
+msgstr "12ﾜｰﾄﾞ"
 
 #: src/seedsigner/views/seed_views.py
 msgid "24 Words"
-msgstr "24ワード"
+msgstr "24ﾜｰﾄﾞ"
 
 #: src/seedsigner/views/seed_views.py
 msgid "BIP-85 Num Words"
-msgstr "BIP-85のワード数"
+msgstr "BIP-85のﾜｰﾄﾞ数"
 
 #: src/seedsigner/views/seed_views.py
 msgid "BIP-85 Index Error"
-msgstr "BIP-85インデックスのエラー"
+msgstr "BIP-85ｲﾝﾃﾞｯｸｽのｴﾗｰ"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Invalid Child Index"
-msgstr "無効の子インデックス"
+msgstr "無効の子ｲﾝﾃﾞｯｸｽ"
 
 #: src/seedsigner/views/seed_views.py
 msgid "BIP-85 Child Index must be between 0 and 2^31-1."
-msgstr "BIP-85子インデックスの値は0〜2^31-1の間にする必要がある。"
+msgstr "BIP-85子ｲﾝﾃﾞｯｸｽの値は0〜2^31-1の間にする必要がある。"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Try Again"
+msgid "Try again"
 msgstr "もう一度やってみてください。"
 
 #: src/seedsigner/views/seed_views.py
@@ -1184,34 +1215,34 @@ msgstr "省略する"
 #. Inserts the word number (e.g. "Verify Word #1")
 #: src/seedsigner/views/seed_views.py
 msgid "Verify Word #{}"
-msgstr "{}番目のワードを確認"
+msgstr "{}番目のﾜｰﾄﾞを確認"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Review Seed Words"
-msgstr "シードワードを確認"
+msgid "Review seed words"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞを確認"
 
 #. Inserts the word number and the word (e.g. "Word #1 is not "apple"!")
 #: src/seedsigner/views/seed_views.py
 msgid "Word #{} is not \"{}\"!"
-msgstr "{}番目のワードは、「{}」ではありません！"
+msgstr "{}番目のﾜｰﾄﾞは、「{}」ではありません！"
 
 #. User selected the wrong word during the mnemonic backup test (e.g.
 #. incorrectly said the 5th word was "zoo")
 #: src/seedsigner/views/seed_views.py
 msgid "Wrong Word!"
-msgstr "ワードが誤っている！"
+msgstr "ﾜｰﾄﾞが誤っている！"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Verification Error"
-msgstr "確認エラー！"
+msgstr "確認ｴﾗｰ！"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Backup Verified"
-msgstr "バックアップに誤りがないことを確認しました。"
+msgstr "ﾊﾞｯｸｱｯﾌﾟに誤りがないことを確認しました。"
 
 #: src/seedsigner/views/seed_views.py
 msgid "All mnemonic backup words were successfully verified!"
-msgstr "バックアップの全てのシードワードに誤りがないことを確認しました。"
+msgstr "ﾊﾞｯｸｱｯﾌﾟの全てのｼｰﾄﾞﾜｰﾄﾞに誤りがないことを確認しました。"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Standard: 25x25"
@@ -1219,7 +1250,7 @@ msgstr "標準: 25x25"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Compact: 21x21"
-msgstr "コンパクト: 21x21"
+msgstr "ｺﾝﾊﾟｸﾄ: 21x21"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Standard: 29x29"
@@ -1227,57 +1258,57 @@ msgstr "標準: 29x29"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Compact: 25x25"
-msgstr "コンパクト: 25x25"
+msgstr "ｺﾝﾊﾟｸﾄ: 25x25"
 
 #: src/seedsigner/views/seed_views.py
 msgid "SeedQR Format"
-msgstr "シードQRの形式"
+msgstr "ｼｰﾄﾞQRの形式"
 
 #: src/seedsigner/views/seed_views.py
 msgid "SeedQR is your private key!"
-msgstr "シードQRとは、秘密鍵と同然です！"
+msgstr "ｼｰﾄﾞQRとは、秘密鍵と同然です！"
 
 #: src/seedsigner/views/seed_views.py
 msgid ""
 "Never photograph or scan it into a device that connects to the internet."
-msgstr "インターネットに接続可能な機器等に撮影されたり読み込まれたりしないよう、ご注意ください！"
+msgstr "ｲﾝﾀｰﾈｯﾄに接続可能な機器等に撮影されたり読み込まれたりしないよう、ご注意ください！"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Confirm SeedQR"
-msgstr "シードQRを確認する"
+msgstr "ｼｰﾄﾞQRを確認する"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Confirm SeedQR?"
-msgstr "シードQRを確認する？"
+msgstr "ｼｰﾄﾞQRを確認する？"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Scan your SeedQR"
-msgstr "シードQRを読み取る"
+msgstr "ｼｰﾄﾞQRを読み取る"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Error!"
-msgstr "エラー！"
+msgstr "ｴﾗｰ！"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Your transcribed SeedQR does not match your original seed!"
-msgstr "書き写されたシードQRの控えが元のシードと一致しない！"
+msgstr "書き写されたｼｰﾄﾞQRの控えが元のｼｰﾄﾞと一致しない！"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Review SeedQR"
-msgstr "シードQRを確認"
+msgstr "ｼｰﾄﾞQRを確認"
+
+#: src/seedsigner/views/seed_views.py
+msgid "Your transcribed SeedQR could not be read!"
+msgstr "書き写されたｼｰﾄﾞQRの控えを読み取れなかった！"
 
 #: src/seedsigner/views/seed_views.py
 msgid ""
 "Your transcribed SeedQR successfully scanned and yielded the same seed."
-msgstr "書き写されたシードQRの控えが無事に読み取られて元のシードと一致する。"
-
-#: src/seedsigner/views/seed_views.py
-msgid "Your transcribed SeedQR could not be read!"
-msgstr "書き写されたシードQRの控えを読み取れなかった！"
+msgstr "書き写されたｼｰﾄﾞQRの控えが無事に読み取られて元のｼｰﾄﾞと一致する。"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Sig type can't be auto-detected from this address. Please specify:"
-msgstr "このアドレスから署名の種類を自動検出できなかったため、署名の種類を指定してください。"
+msgstr "このｱﾄﾞﾚｽから署名の種類を自動検出できなかったため、署名の種類を指定してください。"
 
 #. Option when scanning for a matching address; skips ten addresses ahead
 #: src/seedsigner/views/seed_views.py
@@ -1286,31 +1317,31 @@ msgstr "10を飛ばす"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Cancel"
-msgstr "キャンセル"
+msgstr "ｷｬﾝｾﾙ"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Can't validate a single sig addr without specifying a seed"
-msgstr "シングルシグのアドレスを検証するには、シードの指定が必要です。"
+msgid "Return to transaction"
+msgstr "取引へ戻る"
 
 #: src/seedsigner/views/seed_views.py
-msgid "Scan Descriptor"
-msgstr "descriptorを読み取る"
-
-#: src/seedsigner/views/seed_views.py
-msgid "Return to PSBT"
-msgstr "PSBTへ戻る"
+msgid "Verify addr"
+msgstr "ｱﾄﾞﾚｽを確認"
 
 #: src/seedsigner/views/seed_views.py
 msgid "Signing messages for custom derivation paths not supported"
-msgstr "都度指定の導出パスでメッセージを署名することが未対応です。"
-
-#: src/seedsigner/views/settings_views.py
-msgid "I/O test"
-msgstr "入出力テスト"
+msgstr "都度指定の導出ﾊﾟｽでﾒｯｾｰｼﾞを署名することが未対応です。"
 
 #: src/seedsigner/views/settings_views.py
 msgid "Advanced"
 msgstr "詳細設定"
+
+#: src/seedsigner/views/settings_views.py
+msgid "Hardware"
+msgstr "ﾊｰﾄﾞｳｪｱ"
+
+#: src/seedsigner/views/settings_views.py
+msgid "I/O test"
+msgstr "入出力ﾃｽﾄ"
 
 #: src/seedsigner/views/settings_views.py
 msgid "Dev Options"
@@ -1318,7 +1349,7 @@ msgstr "開発者向け設定"
 
 #: src/seedsigner/views/settings_views.py
 msgid "Persistent Settings enabled. Settings saved to SD card."
-msgstr "非揮発性設定が有効で、設定をSDカードに保存する。"
+msgstr "非揮発性設定が有効で、設定をSDｶｰﾄﾞに保存する。"
 
 #: src/seedsigner/views/settings_views.py
 msgid "Settings updated in temporary memory"
@@ -1326,105 +1357,104 @@ msgstr "揮発性設定を更新済み"
 
 #: src/seedsigner/views/tools_views.py
 msgid "New seed"
-msgstr "新しいシード"
+msgstr "新しいｼｰﾄﾞ"
 
 #: src/seedsigner/views/tools_views.py
 msgid "Calc 12th/24th word"
-msgstr "12・24ワード目を算出"
+msgstr "12・24ﾜｰﾄﾞ目を算出"
+
+#: src/seedsigner/views/tools_views.py
+msgid "Verify address"
+msgstr "ｱﾄﾞﾚｽを確認"
 
 #: src/seedsigner/views/tools_views.py src/seedsigner/views/view.py
 msgid "Tools"
-msgstr "ツール"
+msgstr "道具箱"
 
 #: src/seedsigner/views/tools_views.py
 msgid "12 words"
-msgstr "12ワード"
+msgstr "12ﾜｰﾄﾞ"
 
 #: src/seedsigner/views/tools_views.py
 msgid "24 words"
-msgstr "24ワード"
+msgstr "24ﾜｰﾄﾞ"
 
 #: src/seedsigner/views/tools_views.py
-msgid "Mnemonic Length?"
-msgstr "シードワード数は？"
+msgid "Mnemonic Length"
+msgstr "ｼｰﾄﾞﾜｰﾄﾞ数"
+
+#: src/seedsigner/views/tools_views.py
+msgid "Calculating..."
+msgstr "計算中..."
 
 #. Inserts the number of dice rolls needed for a 12-word mnemonic
 #: src/seedsigner/views/tools_views.py
 msgid "12 words ({} rolls)"
-msgstr "12ワード（{}回投げる）"
+msgstr "12ﾜｰﾄﾞ（{}回投げる）"
 
 #. Inserts the number of dice rolls needed for a 24-word mnemonic
 #: src/seedsigner/views/tools_views.py
 msgid "24 words ({} rolls)"
-msgstr "24ワード（{}回投げる）"
-
-#: src/seedsigner/views/tools_views.py
-msgid "Mnemonic Length"
-msgstr "シードワード数"
+msgstr "24ﾜｰﾄﾞ（{}回投げる）"
 
 #. Label to gather entropy through coin tosses
 #: src/seedsigner/views/tools_views.py
 msgid "Coin flip entropy"
-msgstr "コインを投げてエントロピーを生成する"
+msgstr "ｺｲﾝを投げてｴﾝﾄﾛﾋﾟｰを生成する"
 
 #. Label to gather entropy through user specified BIP-39 word
 #: src/seedsigner/views/tools_views.py
 msgid "Word selection entropy"
-msgstr "ワードを選択してエントロピーを生成する"
+msgstr "ﾜｰﾄﾞを選択してｴﾝﾄﾛﾋﾟｰを生成する"
 
 #. Label to allow user to default entropy as all-zeros
 #: src/seedsigner/views/tools_views.py
 msgid "Finalize with zeros"
-msgstr "ゼロで詰めて完成化する"
+msgstr "ｾﾞﾛで詰めて完成化する"
 
 #. label to calculate the last word of a BIP-39 mnemonic seed phrase
 #: src/seedsigner/views/tools_views.py
 msgid "Final Word Calc"
-msgstr "最後のワードの計算"
+msgstr "最後のﾜｰﾄﾞの計算"
 
 #: src/seedsigner/views/tools_views.py
 msgid "Load seed"
-msgstr "シードを入力"
+msgstr "ｼｰﾄﾞを入力"
 
 #: src/seedsigner/views/tools_views.py
 msgid "Scan wallet descriptor"
-msgstr "ウォレットのdescriptorを読み取る"
+msgstr "ｳｫﾚｯﾄのdescriptorを読み取る"
 
 #. label for addresses where others send us incoming payments
 #: src/seedsigner/views/tools_views.py
-msgid "Receive Addresses"
-msgstr "入金用アドレス"
+msgid "Receive addresses"
+msgstr "入金用ｱﾄﾞﾚｽ"
 
 #. label for addresses that collect the change from our own outgoing payments
 #: src/seedsigner/views/tools_views.py
-msgid "Change Addresses"
-msgstr "お釣り用アドレス"
+msgid "Change addresses"
+msgstr "お釣り用ｱﾄﾞﾚｽ"
 
 #. a status message that our payment addresses are being calculated
 #: src/seedsigner/views/tools_views.py
 msgid "Calculating addrs..."
-msgstr "アドレスを計算中..."
+msgstr "ｱﾄﾞﾚｽを計算中..."
 
 #: src/seedsigner/views/tools_views.py
 msgid "Custom Derivation address explorer not yet implemented"
-msgstr "都度指定の導出パス用のアドレス・エクスプローラーは未対応です。"
+msgstr "都度指定の導出ﾊﾟｽ用のｱﾄﾞﾚｽ･ｴｸｽﾌﾟﾛｰﾗｰは未対応です。"
 
 #: src/seedsigner/views/tools_views.py
 msgid "Single sig descriptors not yet supported"
-msgstr "シングルシグウォレットのdescriptorがまだ未対応"
-
-#. Insert the number of addrs displayed per screen (e.g. "Next 10")
-#: src/seedsigner/views/tools_views.py
-msgid "Next {}"
-msgstr "次の{}"
+msgstr "ｼﾝｸﾞﾙｼｸﾞｳｫﾚｯﾄのdescriptorがまだ未対応"
 
 #: src/seedsigner/views/tools_views.py
 msgid "Receive Addrs"
-msgstr "入金用アドレス"
+msgstr "入金用ｱﾄﾞﾚｽ"
 
 #: src/seedsigner/views/tools_views.py
 msgid "Change Addrs"
-msgstr "お釣り用アドレス"
+msgstr "お釣り用ｱﾄﾞﾚｽ"
 
 #: src/seedsigner/views/view.py
 msgid "Scan"
@@ -1432,14 +1462,14 @@ msgstr "読み取る"
 
 #: src/seedsigner/views/view.py
 msgid "Seeds"
-msgstr "シード箱"
+msgstr "ｼｰﾄﾞ箱"
 
 #: src/seedsigner/views/view.py
 msgid "Restart"
 msgstr "再起動"
 
 #: src/seedsigner/views/view.py
-msgid "Power Off"
+msgid "Power off"
 msgstr "ｼｬｯﾄﾀﾞｳﾝ"
 
 #: src/seedsigner/views/view.py
@@ -1459,14 +1489,14 @@ msgid "Not Yet Implemented"
 msgstr "未実装"
 
 #: src/seedsigner/views/view.py
-msgid "Back to Main Menu"
-msgstr "メニューへ戻る"
+msgid "Back to main menu"
+msgstr "ﾒﾆｭｰへ戻る"
 
 #. The network setting (mainnet/testnet/regtest) doesn't match the provided
 #. derivation path
 #: src/seedsigner/views/view.py
 msgid "Network Mismatch"
-msgstr "ネットワーク不一致"
+msgstr "ﾈｯﾄﾜｰｸ不一致"
 
 #. Button option to alter a setting
 #: src/seedsigner/views/view.py
@@ -1476,15 +1506,27 @@ msgstr "設定を変更する"
 #. Inserts mainnet/testnet/regtest and derivation path
 #: src/seedsigner/views/view.py
 msgid "Current network setting ({}) doesn't match {}."
-msgstr "現在のネットワーク設定（{}）が{}と一致しない。"
+msgstr "現在のﾈｯﾄﾜｰｸ設定（{}）が{}と一致しない。"
 
 #: src/seedsigner/views/view.py
 msgid "System Error"
-msgstr "システムエラー"
+msgstr "ｼｽﾃﾑｴﾗｰ"
 
 #: src/seedsigner/views/view.py
-msgid "Update Setting"
-msgstr "設定を更新する"
+msgid "Hardware Error"
+msgstr "ﾊｰﾄﾞｳｪｱのｴﾗｰ"
+
+#: src/seedsigner/views/view.py
+msgid "Cannot access camera"
+msgstr "ｶﾒﾗとの接続に問題がある"
+
+#: src/seedsigner/views/view.py
+msgid "Disconnect power and check for a loose camera connection."
+msgstr "電源を切って、ｶﾒﾗのｹｰﾌﾞﾙ（両端）が正しくｺﾈｸﾀｰに差し込まれているかをご確認ください。"
+
+#: src/seedsigner/views/view.py
+msgid "Update setting"
+msgstr "設定を更新"
 
 #. Inserts the name of a settings option (e.g. "Persistent Settings" is
 #. currently...)
@@ -1495,3 +1537,13 @@ msgstr "現在の設定により「{}」が無効となっている。"
 #: src/seedsigner/views/view.py
 msgid "Option Disabled"
 msgstr "その機能が無効となっている"
+
+#: src/seedsigner/views/view.py
+msgid "Action Required"
+msgstr "応答が必要"
+
+#: src/seedsigner/views/view.py
+msgid ""
+"You must remove the\n"
+"MicroSD card to continue."
+msgstr "進むには、SDカードを抜く必要がある。"


### PR DESCRIPTION
add new xltns, revise existing xltns to better fit small screen (e.g., full-width katakana --> half-width katakana), redo ja xltns where status changed due to uppercase/lowercase revs in en (generally no effect on ja but status reverted to untranslated in transifex)