### PR TITLE
[Documentation] README update w/better `tx pull` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ for your Transifex user.
 * From the `seedsigner/src/seedsigner/resources/seedsigner-translations` dir run:
 
     ```bash
-    # --all, -a  Whether to download all files (default: false)
-    tx pull --all
+    # --force, -f Force the download of the translations files regardless of whether timestamps on the local computer are newer than those on the server (default: false)
+    # --all, -a   Whether to download all files (default: false)
+    tx pull -f --all
     ```
+    * We use `-f` because as we manipulate the .po files through our PR process, they may
+      end up with newer timestamps even though the translation content has not changed.
+      That timestamp would then mislead the `tx pull` to disregard newer translations.
 
 * Then from the SeedSigner project root, compile the catalogs to process the *.po files into
 *.mo:
@@ -23,6 +27,17 @@ for your Transifex user.
     ```bash
     python setup.py compile_catalog
     ```
+
+### Pulling translations for a specific language
+Use the `--language, -l` flag with the `--force, -f` flag:
+```bash
+# Example: Spanish ("es")
+tx pull -f -l es
+
+# Or comma-separated list
+tx pull -f -l pl,no
+```
+
 
 ### Misc notes
 The `.tx/config` is set to `minimum-perc = 15` (this means that the CLI will skip any


### PR DESCRIPTION
Fixing a minor "gotcha" where the `tx pull` will skip languages where the local .po file is more recent than the last translation in Transifex.

For our use case it is better to `--force` it to pull all translations, regardless of local file timestamp.