### PR TITLE
[l10n/automation] Locale-change detector for the translation bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 # Only check in *.po files since *.mo
 # files can be generated from from them
 *.mo
+
+# Python
+__pycache__/
+*.py[cod]
+.pytest_cache/

--- a/l10n/automation/changed_locales.py
+++ b/l10n/automation/changed_locales.py
@@ -1,0 +1,157 @@
+"""Detect which locales a Transifex write-back changes, for the translation bridge.
+
+The bridge runs in the bot fork after Transifex commits translated catalogs to
+its write branch. It compares those catalogs against the upstream branch and
+reports, per locale, whether the translator-facing content changed. The
+comparison ignores .po header metadata (POT-Creation-Date, PO-Revision-Date,
+Last-Translator, ...), which Transifex rewrites on every commit, so only real
+translation changes are reported, never header churn.
+
+Locales are discovered by scanning l10n/<locale>/LC_MESSAGES/messages.po in both
+trees, so a new language needs no configuration. A separate path-shape guard
+rejects any changed path that is not a locale catalog or the source .pot; that
+guard is the trust boundary against a misconfigured or compromised Transifex.
+
+Run as a script to print the reconcile plan and enforce the guard::
+
+    python l10n/automation/changed_locales.py \
+        --head-root . --base-root .l10n-base --changed-paths changed.txt
+
+It prints {"changed": [...], "converged": [...]} to stdout (a one-line summary to
+stderr) and exits 2 if any changed path falls outside the allowlist.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Tuple
+
+# A locale catalog lives at l10n/<locale>/LC_MESSAGES/messages.po. The source
+# catalog l10n/messages.pot may also change (it is the Transifex source mirror).
+_CATALOG_RE = re.compile(r"^l10n/([^/]+)/LC_MESSAGES/messages\.po$")
+_SOURCE_POT = "l10n/messages.pot"
+
+# Catalog entry key: (msgctxt, singular msgid).
+Key = Tuple[Optional[str], str]
+
+
+def _catalog_path(root: str, locale: str) -> str:
+    return os.path.join(root, "l10n", locale, "LC_MESSAGES", "messages.po")
+
+
+def discover_locales(*roots: str) -> List[str]:
+    """Locale names that have a catalog under l10n/*/LC_MESSAGES/messages.po."""
+    found = set()
+    for root in roots:
+        base = os.path.join(root, "l10n")
+        if not os.path.isdir(base):
+            continue
+        for name in os.listdir(base):
+            if os.path.isfile(_catalog_path(root, name)):
+                found.add(name)
+    return sorted(found)
+
+
+def _load_translations(path: str) -> Optional[Dict[Key, tuple]]:
+    """Load a catalog into {(msgctxt, msgid): (forms, fuzzy)}, or None if absent.
+
+    The header (empty msgid) is skipped, so churn in the header dates never
+    registers as a change; obsolete entries are not yielded by catalog iteration.
+    Babel is imported lazily so this module imports cleanly where Babel is absent.
+    """
+    if not os.path.isfile(path) or os.path.getsize(path) == 0:
+        return None
+
+    from babel.messages.pofile import read_po
+
+    with open(path, "rb") as fh:
+        catalog = read_po(fh)
+
+    out: Dict[Key, tuple] = {}
+    for message in catalog:
+        if not message.id:
+            continue
+        singular = message.id[0] if isinstance(message.id, (list, tuple)) else message.id
+        out[(message.context, singular)] = (_forms(message.string), bool(message.fuzzy))
+    return out
+
+
+def _forms(string) -> tuple:
+    # message.string is a str (singular) or a tuple of plural forms.
+    if isinstance(string, (list, tuple)):
+        return tuple(string)
+    return (string or "",)
+
+
+def changed_locales(head_root: str, base_root: str) -> dict:
+    """Split all discovered locales into changed vs converged.
+
+    A locale is changed when its head catalog differs from the base catalog by
+    translation content (including a catalog appearing or disappearing); it is
+    converged when the two carry identical translations.
+    """
+    changed: List[str] = []
+    converged: List[str] = []
+    for locale in discover_locales(head_root, base_root):
+        head = _load_translations(_catalog_path(head_root, locale))
+        base = _load_translations(_catalog_path(base_root, locale))
+        (converged if head == base else changed).append(locale)
+    return {"changed": changed, "converged": converged}
+
+
+def assert_allowlisted(paths) -> List[str]:
+    """Return the changed paths that are not a locale catalog or the source .pot.
+
+    Any non-empty return value is a guard violation: the caller must refuse to
+    act, because something other than a translation file was touched.
+    """
+    violations = []
+    for path in paths:
+        p = path.strip()
+        if not p or p == _SOURCE_POT or _CATALOG_RE.match(p):
+            continue
+        violations.append(p)
+    return violations
+
+
+def _read_lines(path: Optional[str]) -> List[str]:
+    if not path:
+        return []
+    with open(path, encoding="utf-8") as fh:
+        return [line.strip() for line in fh if line.strip()]
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Detect changed locales for the translation bridge.")
+    p.add_argument("--head-root", required=True, help="tree holding the Transifex-written catalogs")
+    p.add_argument("--base-root", required=True, help="tree holding the upstream base catalogs")
+    p.add_argument("--changed-paths", help="file of changed paths (git diff --name-only) to guard")
+    p.add_argument("--format", choices=["json", "lines"], default="json")
+    return p.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+
+    violations = assert_allowlisted(_read_lines(args.changed_paths))
+    if violations:
+        print("Refusing to act: changed paths outside the translation allowlist:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 2
+
+    result = changed_locales(args.head_root, args.base_root)
+    if args.format == "lines":
+        print("\n".join(result["changed"]))
+    else:
+        print(json.dumps(result))
+    print(f"changed: {len(result['changed'])} "
+          f"({', '.join(result['changed']) or '-'}); "
+          f"converged: {len(result['converged'])}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/tests/conftest.py
+++ b/l10n/automation/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Make the l10n automation modules importable when these tests run.
+
+The translations repo has no main pytest suite; these tests are standalone. Run:
+
+    python -m pytest l10n/automation/tests
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def write_po(path, entries, *, revision="2020-01-01 00:00+0000"):
+    """Write a minimal .po at path. entries: list of {id, str?, plural?, plural_str?, ctx?, fuzzy?}.
+
+    `revision` sets the PO-Revision-Date header so tests can vary header metadata
+    independently of translation content.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = (
+        'msgid ""\nmsgstr ""\n'
+        '"Content-Type: text/plain; charset=UTF-8\\n"\n'
+        f'"PO-Revision-Date: {revision}\\n"\n\n'
+    )
+    chunks = [header]
+    for e in entries:
+        block = ""
+        if e.get("fuzzy"):
+            block += "#, fuzzy\n"
+        if e.get("ctx"):
+            block += f'msgctxt "{e["ctx"]}"\n'
+        block += f'msgid "{e["id"]}"\n'
+        if e.get("plural"):
+            block += f'msgid_plural "{e["plural"]}"\n'
+            block += f'msgstr[0] "{e.get("str", "")}"\n'
+            block += f'msgstr[1] "{e.get("plural_str", "")}"\n'
+        else:
+            block += f'msgstr "{e.get("str", "")}"\n'
+        chunks.append(block + "\n")
+    path.write_text("".join(chunks), encoding="utf-8")
+    return str(path)

--- a/l10n/automation/tests/test_changed_locales.py
+++ b/l10n/automation/tests/test_changed_locales.py
@@ -1,0 +1,105 @@
+"""Tests for the translation-bridge locale-change detector and path guard.
+
+Run standalone (not part of any main suite):
+
+    python -m pytest l10n/automation/tests -q
+"""
+
+import json
+
+import pytest
+
+# Parsing real .po files needs Babel; skip cleanly where it is absent.
+pytest.importorskip("babel")
+
+import changed_locales  # noqa: E402
+from conftest import write_po  # noqa: E402
+
+
+def _po(root, locale):
+    return root / "l10n" / locale / "LC_MESSAGES" / "messages.po"
+
+
+def test_header_only_change_is_converged(tmp_path):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}], revision="2020-01-01 00:00+0000")
+    write_po(_po(head, "de"), [{"id": "Hello", "str": "Hallo"}], revision="2026-06-23 12:00+0000")
+    assert changed_locales.changed_locales(str(head), str(base)) == {"changed": [], "converged": ["de"]}
+
+
+def test_msgstr_change_is_changed(tmp_path):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "de"), [{"id": "Hello", "str": "Servus"}])
+    result = changed_locales.changed_locales(str(head), str(base))
+    assert result == {"changed": ["de"], "converged": []}
+
+
+def test_new_locale_is_changed(tmp_path):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "fr"), [{"id": "Hello", "str": "Bonjour"}])
+    result = changed_locales.changed_locales(str(head), str(base))
+    assert result == {"changed": ["fr"], "converged": ["de"]}
+
+
+def test_removed_locale_is_changed(tmp_path):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "fr"), [{"id": "Hello", "str": "Bonjour"}])
+    result = changed_locales.changed_locales(str(head), str(base))
+    assert set(result["changed"]) == {"de", "fr"}
+    assert result["converged"] == []
+
+
+def test_fuzzy_toggle_is_changed(tmp_path):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "de"), [{"id": "Hello", "str": "Hallo", "fuzzy": True}])
+    assert changed_locales.changed_locales(str(head), str(base))["changed"] == ["de"]
+
+
+def test_allowlist_accepts_any_locale_and_source():
+    assert changed_locales.assert_allowlisted([
+        "l10n/de/LC_MESSAGES/messages.po",
+        "l10n/zh_Hans_CN/LC_MESSAGES/messages.po",
+        "l10n/xx/LC_MESSAGES/messages.po",
+        "l10n/messages.pot",
+    ]) == []
+
+
+def test_allowlist_flags_non_translation_paths():
+    violations = changed_locales.assert_allowlisted([
+        "setup.py",
+        ".github/workflows/evil.yml",
+        "fonts/x.ttf",
+        "l10n/de/LC_MESSAGES/messages.mo",
+    ])
+    assert set(violations) == {
+        "setup.py", ".github/workflows/evil.yml", "fonts/x.ttf",
+        "l10n/de/LC_MESSAGES/messages.mo",
+    }
+
+
+def test_cli_json_output(tmp_path, capsys):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "de"), [{"id": "Hello", "str": "Servus"}])
+    changed = tmp_path / "changed.txt"
+    changed.write_text("l10n/de/LC_MESSAGES/messages.po\n", encoding="utf-8")
+    rc = changed_locales.main(["--head-root", str(head), "--base-root", str(base),
+                               "--changed-paths", str(changed)])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == {"changed": ["de"], "converged": []}
+
+
+def test_cli_guard_violation_exits_2(tmp_path):
+    head, base = tmp_path / "head", tmp_path / "base"
+    write_po(_po(base, "de"), [{"id": "Hello", "str": "Hallo"}])
+    write_po(_po(head, "de"), [{"id": "Hello", "str": "Hallo"}])
+    changed = tmp_path / "changed.txt"
+    changed.write_text(".github/workflows/evil.yml\n", encoding="utf-8")
+    rc = changed_locales.main(["--head-root", str(head), "--base-root", str(base),
+                               "--changed-paths", str(changed)])
+    assert rc == 2


### PR DESCRIPTION
> [!NOTE]
> One of the Transifex translation-bridge PRs (#93, #94, #95). This PR has no dependencies on the others.

## Description

### Problem

We want to bring Transifex translations into this repo as reviewable, per-locale pull requests, automating the manual `tx pull` flow in the README. The foundational piece is a pure, testable way to decide which locales a Transifex write-back actually changed, ignoring the `.po` header churn Transifex rewrites on every commit, and to refuse any change that is not a translation catalog.

### Solution

Adds `l10n/automation/changed_locales.py`. It discovers locales by scanning `l10n/<locale>/LC_MESSAGES/messages.po` across two on-disk trees and reports, per locale, whether the translator-facing content (msgstr, plural forms, fuzzy flag) differs, ignoring header metadata like `POT-Creation-Date` and `PO-Revision-Date`. Locales are discovered rather than configured, so a new language needs no edits. A separate path-shape guard rejects any changed path that is not a locale catalog or `l10n/messages.pot`, exiting non-zero so a caller can abort before doing anything. The module is network-free and git-free (it diffs two directory trees handed to it) and imports Babel lazily.

Also adds standalone unit tests (header-only change stays converged, a msgstr change is detected, new and removed locales, fuzzy toggle, the guard accept/reject cases, and the CLI), and Python entries to `.gitignore`.

This pull request is categorized as a:
- [x] Other (l10n automation)

## Checklist

- [x] I added tests.
- [x] I ran the tests locally: `python -m pytest l10n/automation/tests` (these are standalone; this repo has no main pytest suite).

