### PR TITLE
[l10n/automation] Format-placeholder integrity check

### DIFF
--- a/l10n/automation/placeholder_check.py
+++ b/l10n/automation/placeholder_check.py
@@ -1,0 +1,208 @@
+"""Check that translations preserve their source string's format placeholders.
+
+SeedSigner source strings use Python str.format fields ({} and {name}). A
+translation that renames a field, or adds one, crashes at runtime when the
+code calls .format on it (KeyError/IndexError); one that drops a field
+"works" but silently loses the substituted value. Both mean the translation
+is broken, so this check is meant to block a translation PR rather than
+advise.
+
+For every catalog entry whose msgid contains at least one format field, each
+non-empty translated form must carry a compatible signature:
+
+* the number of automatic positional fields ({}) must match, and
+* the set of named fields ({name}) must match.
+
+Plural entries compare each msgstr[i] against the singular and the plural
+msgid: a form is fine if it matches either, since which grammatical numbers
+each form covers varies by language. Entries whose msgid has no format fields
+are skipped entirely; braces a translator adds to plain text can never crash
+because the code never calls .format on those strings.
+
+Fuzzy entries are checked like any other: they are compiled whenever
+--use-fuzzy is in play, so a broken placeholder in a fuzzy entry still
+crashes. Issues carry a "fuzzy" flag so consumers can present them separately.
+
+Run as a script to check catalogs and print a JSON report::
+
+    python l10n/automation/placeholder_check.py --root . --locale de
+
+It prints {"issues": [...], "checked_locales": [...], "counts": ...} to stdout
+(a one-line summary to stderr) and exits 1 if any issue was found.
+"""
+
+import argparse
+import json
+import os
+import string
+import sys
+from typing import Dict, List, Optional, Tuple
+
+# Placeholder signature: (count of automatic {} fields, set of named fields).
+Signature = Tuple[int, frozenset]
+
+
+def extract_signature(text: str) -> Optional[Signature]:
+    """Return the format-field signature of ``text``, or None if it does not
+    parse as a format string (e.g. a stray unmatched brace).
+
+    {{ and }} are literal braces and contribute no field. A field with an
+    empty name is an automatic positional ({}); anything else (including
+    explicit indexes like {0}) counts as named, matched by exact name.
+    """
+    positional = 0
+    named = set()
+    try:
+        for _literal, field_name, _spec, _conversion in string.Formatter().parse(text):
+            if field_name is None:
+                continue
+            if field_name == "":
+                positional += 1
+            else:
+                named.add(field_name)
+    except ValueError:
+        return None
+    return (positional, frozenset(named))
+
+
+def _signature_fields(sig: Signature) -> List[str]:
+    """Render a signature as a sorted list of field strings, for reporting."""
+    positional, named = sig
+    return ["{}"] * positional + [f"{{{name}}}" for name in sorted(named)]
+
+
+def _forms(message) -> List[Tuple[str, str]]:
+    """The translated forms of a Babel message as (label, text) pairs."""
+    if isinstance(message.string, (list, tuple)):
+        return [(f"msgstr[{i}]", form) for i, form in enumerate(message.string)]
+    return [("msgstr", message.string or "")]
+
+
+def check_catalog(path: str, locale: str) -> List[dict]:
+    """Check one .po file; returns a list of issue dicts (empty when clean)."""
+    from babel.messages.pofile import read_po
+
+    with open(path, "rb") as fh:
+        catalog = read_po(fh)
+
+    issues = []
+    for message in catalog:
+        if not message.id:
+            # The header message has an empty id; skip it.
+            continue
+
+        if isinstance(message.id, (list, tuple)):
+            singular = message.id[0]
+            sources = [form for form in message.id if form]
+        else:
+            singular = message.id
+            sources = [message.id]
+
+        # Signatures the source side offers. Entries whose msgid has no format
+        # fields are not format strings; skip them.
+        source_sigs = [extract_signature(source) for source in sources]
+        if any(sig is None for sig in source_sigs):
+            # The source itself does not parse; nothing sane to compare against.
+            continue
+        if all(sig == (0, frozenset()) for sig in source_sigs):
+            continue
+
+        for label, form in _forms(message):
+            if not form:
+                # Untranslated; nothing to check.
+                continue
+            form_sig = extract_signature(form)
+            if form_sig is None:
+                issues.append({
+                    "locale": locale,
+                    "msgctxt": message.context,
+                    "msgid": singular,
+                    "form": label,
+                    "problem": "malformed",
+                    "expected": _signature_fields(source_sigs[0]),
+                    "found": None,
+                    "fuzzy": bool(message.fuzzy),
+                })
+            elif form_sig not in source_sigs:
+                issues.append({
+                    "locale": locale,
+                    "msgctxt": message.context,
+                    "msgid": singular,
+                    "form": label,
+                    "problem": "mismatch",
+                    "expected": _signature_fields(source_sigs[0]),
+                    "found": _signature_fields(form_sig),
+                    "fuzzy": bool(message.fuzzy),
+                })
+
+    return issues
+
+
+def _catalog_path(root: str, locale: str) -> str:
+    return os.path.join(root, "l10n", locale, "LC_MESSAGES", "messages.po")
+
+
+def discover_locales(root: str) -> List[str]:
+    """Locale names that have a catalog under l10n/*/LC_MESSAGES/messages.po."""
+    base = os.path.join(root, "l10n")
+    if not os.path.isdir(base):
+        return []
+    return sorted(name for name in os.listdir(base)
+                  if os.path.isfile(_catalog_path(root, name)))
+
+
+def check_locales(root: str, locales: Optional[List[str]] = None) -> Dict:
+    """Check the given locales (default: all discovered) under ``root``."""
+    if not locales:
+        locales = discover_locales(root)
+
+    issues = []
+    checked = []
+    for locale in locales:
+        path = _catalog_path(root, locale)
+        if not os.path.isfile(path):
+            continue
+        issues.extend(check_catalog(path, locale))
+        checked.append(locale)
+
+    return {
+        "issues": issues,
+        "checked_locales": checked,
+        "counts": {
+            "issues": len(issues),
+            "locales_with_issues": len({issue["locale"] for issue in issues}),
+        },
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check that translations preserve format placeholders.")
+    parser.add_argument("--root", default=".",
+                        help="repo root containing l10n/ (default: cwd)")
+    parser.add_argument("--locale", action="append", default=None,
+                        help="locale to check; repeatable (default: all)")
+    args = parser.parse_args(argv)
+
+    report = check_locales(args.root, args.locale)
+
+    payload = json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True)
+    # Write through the binary buffer: translated strings are non-ASCII and the
+    # runner's stdout encoding must not matter. The buffer is absent when
+    # stdout is substituted (captured in tests); the text layer handles it then.
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        sys.stdout.write(payload + "\n")
+    else:
+        buffer.write((payload + "\n").encode("utf-8"))
+        buffer.flush()
+
+    counts = report["counts"]
+    print(f"placeholder check: {counts['issues']} issue(s) across "
+          f"{counts['locales_with_issues']} locale(s), "
+          f"{len(report['checked_locales'])} checked", file=sys.stderr)
+    return 1 if report["issues"] else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/tests/test_placeholder_check.py
+++ b/l10n/automation/tests/test_placeholder_check.py
@@ -1,0 +1,166 @@
+"""Tests for the format-placeholder integrity check."""
+
+import json
+
+import pytest
+
+pytest.importorskip("babel")
+
+import placeholder_check  # noqa: E402
+from conftest import write_po  # noqa: E402
+
+
+def check(tmp_path, entries, locale="de"):
+    write_po(tmp_path / "l10n" / locale / "LC_MESSAGES" / "messages.po", entries)
+    return placeholder_check.check_locales(str(tmp_path), [locale])
+
+
+def test_clean_catalog_has_no_issues(tmp_path):
+    report = check(tmp_path, [
+        {"id": "Hello", "str": "Hallo"},
+        {"id": "Enter {name}", "str": "{name} eingeben"},
+        {"id": "{} of {}", "str": "{} von {}"},
+    ])
+    assert report["issues"] == []
+    assert report["checked_locales"] == ["de"]
+    assert report["counts"] == {"issues": 0, "locales_with_issues": 0}
+
+
+def test_named_field_replaced_by_positional_is_flagged(tmp_path):
+    # The real-world case this check exists for: a translation swapping the
+    # named {mnemonic_length} field for a bare {} crashes .format at runtime.
+    report = check(tmp_path, [{
+        "id": "Enter your {mnemonic_length}-word BIP-39 mnemonic.",
+        "str": "Angi ditt {}-ords BIP-39 mnemonic.",
+    }], locale="no")
+
+    assert len(report["issues"]) == 1
+    issue = report["issues"][0]
+    assert issue["problem"] == "mismatch"
+    assert issue["expected"] == ["{mnemonic_length}"]
+    assert issue["found"] == ["{}"]
+    assert issue["locale"] == "no"
+
+
+def test_dropped_positional_field_is_flagged(tmp_path):
+    report = check(tmp_path, [{"id": "{} of {}", "str": "{} von allen"}])
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["expected"] == ["{}", "{}"]
+    assert report["issues"][0]["found"] == ["{}"]
+
+
+def test_renamed_field_is_flagged(tmp_path):
+    report = check(tmp_path, [{"id": "Enter {name}", "str": "{nom} eingeben"}])
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["found"] == ["{nom}"]
+
+
+def test_untranslated_entry_is_skipped(tmp_path):
+    report = check(tmp_path, [{"id": "Enter {name}", "str": ""}])
+    assert report["issues"] == []
+
+
+def test_msgid_without_fields_is_not_a_format_string(tmp_path):
+    # Braces a translator adds to plain text can never crash: the code never
+    # calls .format on strings whose source has no fields. Even an unmatched
+    # brace is fine here.
+    report = check(tmp_path, [
+        {"id": "Press OK", "str": "Druecke {OK}"},
+        {"id": "Amount", "str": "Betrag {"},
+    ])
+    assert report["issues"] == []
+
+
+def test_malformed_translation_of_format_string_is_flagged(tmp_path):
+    report = check(tmp_path, [{"id": "Enter {name}", "str": "{name eingeben"}])
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["problem"] == "malformed"
+    assert report["issues"][0]["found"] is None
+
+
+def test_literal_braces_do_not_count_as_fields(tmp_path):
+    report = check(tmp_path, [{"id": "Enter {name}", "str": "{{x}} {name}"}])
+    assert report["issues"] == []
+
+
+def test_plural_form_may_match_singular_or_plural_signature(tmp_path):
+    # "one word" (no field) / "{} words": each translated form may follow
+    # either source signature, since which grammatical numbers a form covers
+    # varies by language.
+    report = check(tmp_path, [{
+        "id": "one word", "plural": "{} words",
+        "str": "ein Wort", "plural_str": "{} Woerter",
+    }])
+    assert report["issues"] == []
+
+
+def test_plural_form_matching_neither_signature_is_flagged(tmp_path):
+    report = check(tmp_path, [{
+        "id": "one word", "plural": "{} words",
+        "str": "ein Wort", "plural_str": "{} von {} Woertern",
+    }])
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["form"] == "msgstr[1]"
+
+
+def test_fuzzy_issue_is_flagged_and_marked(tmp_path):
+    # Fuzzy entries still compile under --use-fuzzy, so they are checked; the
+    # flag lets consumers present them separately.
+    report = check(tmp_path, [
+        {"id": "Enter {name}", "str": "{} eingeben", "fuzzy": True},
+    ])
+    assert len(report["issues"]) == 1
+    assert report["issues"][0]["fuzzy"] is True
+
+
+def test_msgctxt_is_reported(tmp_path):
+    report = check(tmp_path, [
+        {"id": "Enter {name}", "str": "{} eingeben", "ctx": "menu"},
+    ])
+    assert report["issues"][0]["msgctxt"] == "menu"
+
+
+def test_all_locales_discovered_when_none_specified(tmp_path):
+    write_po(tmp_path / "l10n" / "de" / "LC_MESSAGES" / "messages.po",
+             [{"id": "Enter {name}", "str": "{} eingeben"}])
+    write_po(tmp_path / "l10n" / "ja" / "LC_MESSAGES" / "messages.po",
+             [{"id": "Enter {name}", "str": "{name}"}])
+
+    report = placeholder_check.check_locales(str(tmp_path))
+    assert report["checked_locales"] == ["de", "ja"]
+    assert report["counts"] == {"issues": 1, "locales_with_issues": 1}
+
+
+def test_missing_locale_is_ignored(tmp_path):
+    write_po(tmp_path / "l10n" / "de" / "LC_MESSAGES" / "messages.po",
+             [{"id": "Hello", "str": "Hallo"}])
+    report = placeholder_check.check_locales(str(tmp_path), ["de", "xx"])
+    assert report["checked_locales"] == ["de"]
+
+
+def test_cli_exit_codes_and_json(tmp_path, capsysbinary):
+    write_po(tmp_path / "l10n" / "de" / "LC_MESSAGES" / "messages.po",
+             [{"id": "Enter {name}", "str": "{} eingeben"}])
+
+    rc = placeholder_check.main(["--root", str(tmp_path), "--locale", "de"])
+    out = capsysbinary.readouterr().out.decode("utf-8")
+
+    assert rc == 1
+    report = json.loads(out)
+    assert report["counts"]["issues"] == 1
+
+    # Clean run exits 0
+    write_po(tmp_path / "l10n" / "de" / "LC_MESSAGES" / "messages.po",
+             [{"id": "Enter {name}", "str": "{name} eingeben"}])
+    assert placeholder_check.main(["--root", str(tmp_path)]) == 0
+
+
+def test_extract_signature():
+    f = placeholder_check.extract_signature
+    assert f("plain") == (0, frozenset())
+    assert f("{} and {}") == (2, frozenset())
+    assert f("{a} and {b}") == (0, frozenset({"a", "b"}))
+    assert f("{} and {a}") == (1, frozenset({"a"}))
+    assert f("{{literal}}") == (0, frozenset())
+    assert f("{0} and {0}") == (0, frozenset({"0"}))
+    assert f("broken {") is None


### PR DESCRIPTION
> [!NOTE]
> One of the translation-review automation PRs (#96, #97, #98, #99, #100). Runtime code has no dependencies on the others; the tests reuse the `write_po` helper from the test conftest introduced in #93.

## Description

### Problem

Source strings use Python `str.format` fields (`{}` and `{name}`). A translation that renames or adds a field crashes at runtime when the code formats it (`KeyError`/`IndexError`); one that drops a field "works" but silently loses the substituted value. This is not hypothetical: the current `es` catalog drops `{mnemonic_length}` from the final-word explanation, and a past `no` translation replaced the named field with a bare `{}`, which crashes the screen. Nothing checks for this today.

### Solution

Adds `l10n/automation/placeholder_check.py`. Babel does not emit `python-brace-format` flags, so fields are parsed directly with `string.Formatter`. For every catalog entry whose msgid contains at least one field, each non-empty translated form must match the source signature: the same count of positional `{}` fields and the same set of named fields. Plural forms may match either the singular or the plural msgid, since which grammatical numbers each form covers varies by language. Entries whose msgid has no fields are skipped entirely: braces a translator adds to plain text can never crash, because `.format` is never called on those strings. Fuzzy entries are checked like any other (they compile under `--use-fuzzy`) and issues carry a `fuzzy` flag so consumers can present them separately.

The CLI prints a JSON report and exits 1 when issues are found, so a workflow can use it as a blocking check. Locales are discovered by scanning, or selected with repeatable `--locale` args.

This pull request is categorized as a:
- [x] Other (l10n automation)

## Checklist

- [x] I added tests.
- [x] I ran the tests locally: `python -m pytest l10n/automation/tests` (standalone; this repo has no main pytest suite).

