### PR TITLE
[l10n/automation] Emit a review manifest from the screenshot diff

### DIFF
--- a/.github/diff_report/diff_screenshots.py
+++ b/.github/diff_report/diff_screenshots.py
@@ -1,31 +1,38 @@
 """
-Utility to compare screenshots before and after a change and generate a report of the
-differences.
+Compare screenshots before and after a change; report the differences.
 
-Expected usage in a GitHub Actions workflow; compare `dev` with the `$INCOMING_CHANGES_REF` in the
-associated PR or merge that triggered the CI run:
-python src/seedsigner/resources/seedsigner-translations/.github/diff_report/diff_screenshots.py ./artifacts/dev ./artifacts/incoming ./artifacts/diff $INCOMING_CHANGES_REF
+Produces, in output_dir:
+
+* before/ and after/ copies of every added, removed or changed screenshot,
+  keyed by the shared path fragment <locale>/<section>/<ScreenshotName>.png
+* manifest.json, a machine-readable summary of the diff (plus any check
+  reports passed in) for downstream automation
+* index.html, a human-readable report of the same
+
+Expected usage in a GitHub Actions workflow; compare `dev` with the
+`$INCOMING_CHANGES_REF` in the associated PR or merge that triggered the CI run:
+
+python src/seedsigner/resources/seedsigner-translations/.github/diff_report/diff_screenshots.py \
+    ./artifacts/dev ./artifacts/incoming ./artifacts/diff $INCOMING_CHANGES_REF
+
+The optional --repository / --pr-number / --head-sha / --base-ref args embed
+the PR coordinates in the manifest so a trusted follow-up job can bind it to
+the triggering run; --placeholder-report / --overflow-report embed those
+check results. All are omitted on plain push runs, leaving manifest fields
+null.
 """
 import argparse
 import glob
 import hashlib
+import json
 import os
 import pathlib
 import shutil
+from datetime import datetime, timezone
 
+SCHEMA_VERSION = "1.0"
+STREAM = "translation-review"
 
-parser = argparse.ArgumentParser(prog=__name__)
-
-parser.add_argument("before_dir", type=str, help="Directory containing screenshots before the incoming changes")
-parser.add_argument("after_dir", type=str, help="Directory containing screenshots after the incoming changes")
-parser.add_argument("output_dir", type=str, help="Directory to save the screenshots diff report")
-parser.add_argument("incoming_changes_ref", type=str, help="Branch name or commit hash that contains the incoming changes")
-
-args = parser.parse_args()
-
-# `before_dir` includes the branch name we'll be merging into
-baseline_branch = args.before_dir.split(os.path.sep)[-1]
-incoming_changes_ref = args.incoming_changes_ref
 
 def list_files_recursively(path: str) -> list[str]:
     """ Return a list of paths to all png files in the directory tree """
@@ -35,104 +42,208 @@ def list_files_recursively(path: str) -> list[str]:
 def compute_file_hash(file_path: str) -> str:
     """ Return the file hash using sha256 """
     hash_func = hashlib.new('sha256')
-    
+
     with open(file_path, 'rb') as file:
         while chunk := file.read(8192):  # Read the file in chunks of 8192 bytes
             hash_func.update(chunk)
-    
+
     return hash_func.hexdigest()
 
 
-def get_pathname_fragment(path:str) -> str:
+def get_pathname_fragment(path: str) -> str:
     """ Extract the last 3 parts of the path:
             en/tools_views/ToolsCalcFinalWordDoneView.png
 
         These paths will be the same in the "before" and "after" directories.
+        Fragments always use forward slashes, regardless of OS.
     """
     parts = path.split(os.path.sep)
     if len(parts) < 3:
         raise ValueError(f"Path should have at least 3 parts: {path}")
-    return os.path.sep.join(parts[-3:])
+    return "/".join(parts[-3:])
 
 
-def get_locale_and_screenshot_name(path: str) -> tuple[str, str]:
-    """ Parse the path to extract the locale and the screenshot name.
+def get_locale_and_screenshot_name(fragment: str) -> tuple[str, str]:
+    """ Parse a path fragment to extract the locale and the screenshot name.
 
-        Assumes we're working with a path like:
+        Assumes we're working with a fragment like:
             en/tools_views/ToolsCalcFinalWordDoneView.png
     """
-    parts = path.split(os.path.sep)
+    parts = fragment.split("/")
     if len(parts) != 3:
-        raise ValueError(f"Path should have 3 parts: {path}")
+        raise ValueError(f"Path should have 3 parts: {fragment}")
     return parts[0], parts[-1].split(".")[0]
 
 
-# Recursively list and hash all png files in the "before" directory
-before_screenshots = {}
-paths_before = []
-for file in list_files_recursively(args.before_dir):
-    screenshot_path = get_pathname_fragment(file)
-    before_screenshots[screenshot_path] = compute_file_hash(file)
-    paths_before.append(screenshot_path)
+def diff_screenshot_trees(before_dir: str, after_dir: str) -> dict:
+    """ Hash every png on both sides and bucket the fragments into
+        added / removed / changed. """
+    before_hashes = {}
+    for file in list_files_recursively(before_dir):
+        before_hashes[get_pathname_fragment(file)] = compute_file_hash(file)
 
-# Do the same for the "after" directory, but do the diff while we're here
-only_in_after = []
-diffs: list[str] = []
-paths_after = []
-for file in list_files_recursively(args.after_dir):
-    screenshot_path = get_pathname_fragment(file)
-    if screenshot_path not in before_screenshots:
-        only_in_after.append(screenshot_path)
+    added = []
+    changed = []
+    after_fragments = set()
+    for file in list_files_recursively(after_dir):
+        fragment = get_pathname_fragment(file)
+        after_fragments.add(fragment)
+        if fragment not in before_hashes:
+            added.append(fragment)
+        elif before_hashes[fragment] != compute_file_hash(file):
+            changed.append(fragment)
 
-    elif before_screenshots[screenshot_path] != compute_file_hash(file):
-        diffs.append(screenshot_path)
-    
-    paths_after.append(screenshot_path)
+    removed = sorted(set(before_hashes) - after_fragments)
 
-only_in_before = set(paths_before) - set(paths_after)
+    return {
+        "added": sorted(added),
+        "removed": removed,
+        "changed": sorted(changed),
+        "counts": {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+            "total_before": len(before_hashes),
+            "total_after": len(after_fragments),
+        },
+    }
 
-html_content = "<h1>Screenshots diff report</h1>"
-html_content += f"""<p>Comparing {baseline_branch} to {incoming_changes_ref}</p>"""
-output_dir_before = os.path.join(args.output_dir, "before")
-output_dir_after = os.path.join(args.output_dir, "after")
-os.makedirs(output_dir_before, exist_ok=True)
-os.makedirs(output_dir_after, exist_ok=True)
 
-for screenshot_path in only_in_before:
-    locale, screenshot_name = get_locale_and_screenshot_name(screenshot_path)
-    print(f"Screenshot only in before: {locale}: {screenshot_name}")
-    os.makedirs(os.path.join(output_dir_before, os.path.dirname(screenshot_path)), exist_ok=True)
-    shutil.copy(os.path.join(args.before_dir, screenshot_path), os.path.join(output_dir_before, screenshot_path))
-    html_content += f"<p>{locale}: REMOVED {screenshot_name}</br><img src='{os.path.join('before', screenshot_path)}'></p></br></br>"
+def copy_screenshots(diff: dict, before_dir: str, after_dir: str, output_dir: str):
+    """ Copy every flagged screenshot into output_dir/before and
+        output_dir/after, preserving the path fragment. """
+    output_dir_before = os.path.join(output_dir, "before")
+    output_dir_after = os.path.join(output_dir, "after")
+    os.makedirs(output_dir_before, exist_ok=True)
+    os.makedirs(output_dir_after, exist_ok=True)
 
-for screenshot_path in only_in_after:
-    locale, screenshot_name = get_locale_and_screenshot_name(screenshot_path)
-    print(f"Screenshot only in after: {locale}: {screenshot_name}")
-    os.makedirs(os.path.join(output_dir_after, os.path.dirname(screenshot_path)), exist_ok=True)
-    shutil.copy(os.path.join(args.after_dir, screenshot_path), os.path.join(output_dir_after, screenshot_path))
-    html_content += f"<p>{locale}: ADDED {screenshot_name}</br><img src='{os.path.join('after', screenshot_path)}'></p></br></br>"
+    def copy(src_root: str, dst_root: str, fragment: str):
+        relpath = fragment.replace("/", os.path.sep)
+        os.makedirs(os.path.join(dst_root, os.path.dirname(relpath)), exist_ok=True)
+        shutil.copy(os.path.join(src_root, relpath), os.path.join(dst_root, relpath))
 
-for screenshot_path in diffs:
-    locale, screenshot_name = get_locale_and_screenshot_name(screenshot_path)
-    print(f"Screenshot different: {locale}: {screenshot_name}")
-    # Copy both screenshots to the output dir
-    os.makedirs(os.path.join(output_dir_before, os.path.dirname(screenshot_path)), exist_ok=True)
-    os.makedirs(os.path.join(output_dir_after, os.path.dirname(screenshot_path)), exist_ok=True)
-    shutil.copy(os.path.join(args.before_dir, screenshot_path), os.path.join(output_dir_before, screenshot_path))
-    shutil.copy(os.path.join(args.after_dir, screenshot_path), os.path.join(output_dir_after, screenshot_path))
-    html_content += f"<p>{locale}: {screenshot_name}</br><img src='{os.path.join('before', screenshot_path)}'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src='{os.path.join('after', screenshot_path)}'></p></br></br>"
+    for fragment in diff["removed"]:
+        copy(before_dir, output_dir_before, fragment)
 
-if not only_in_after and not only_in_before and not diffs:
-    print("No differences found")
-    html_content += "<h1>No differences found</h1>"
+    for fragment in diff["added"]:
+        copy(after_dir, output_dir_after, fragment)
 
-script_dir = pathlib.Path(__file__).parent.resolve()
-html_output = ""
-with open(os.path.join(script_dir, "index.html"), "r") as f:
-    html_output = f.read().replace("{{ content }}", html_content)
+    for fragment in diff["changed"]:
+        copy(before_dir, output_dir_before, fragment)
+        copy(after_dir, output_dir_after, fragment)
 
-with open(os.path.join(args.output_dir, "index.html"), "w") as f:
-    f.write(html_output)
 
-# Also copy the css file; source: https://github.com/picocss/pico
-shutil.copy(os.path.join(script_dir, "pico.min.css"), os.path.join(args.output_dir, "pico.min.css"))
+def load_check_report(path, label: str, notes: list):
+    """ Load a check's JSON output for embedding in the manifest. A missing or
+        unreadable report is recorded as a note rather than a crash, so the
+        manifest still says what it does not know. """
+    if not path:
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        notes.append(f"{label} report at {path!r} could not be read: {e}")
+        return None
+
+
+def build_manifest(diff: dict, args: argparse.Namespace, notes: list) -> dict:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "stream": STREAM,
+        "generated_at": datetime.now(timezone.utc)
+            .replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "repository": args.repository,
+        "pr": {
+            "number": args.pr_number,
+            "head_sha": args.head_sha,
+            "base_ref": args.base_ref,
+        },
+        "screenshots": diff,
+        "checks": {
+            "placeholder": load_check_report(args.placeholder_report, "placeholder", notes),
+            "overflow": load_check_report(args.overflow_report, "overflow", notes),
+        },
+        "notes": notes,
+    }
+
+
+def build_html(diff: dict, baseline_branch: str, incoming_changes_ref: str) -> str:
+    html_content = "<h1>Screenshots diff report</h1>"
+    html_content += f"""<p>Comparing {baseline_branch} to {incoming_changes_ref}</p>"""
+
+    for fragment in diff["removed"]:
+        locale, screenshot_name = get_locale_and_screenshot_name(fragment)
+        print(f"Screenshot only in before: {locale}: {screenshot_name}")
+        html_content += f"<p>{locale}: REMOVED {screenshot_name}</br><img src='before/{fragment}'></p></br></br>"
+
+    for fragment in diff["added"]:
+        locale, screenshot_name = get_locale_and_screenshot_name(fragment)
+        print(f"Screenshot only in after: {locale}: {screenshot_name}")
+        html_content += f"<p>{locale}: ADDED {screenshot_name}</br><img src='after/{fragment}'></p></br></br>"
+
+    for fragment in diff["changed"]:
+        locale, screenshot_name = get_locale_and_screenshot_name(fragment)
+        print(f"Screenshot different: {locale}: {screenshot_name}")
+        html_content += f"<p>{locale}: {screenshot_name}</br><img src='before/{fragment}'>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<img src='after/{fragment}'></p></br></br>"
+
+    if not diff["added"] and not diff["removed"] and not diff["changed"]:
+        print("No differences found")
+        html_content += "<h1>No differences found</h1>"
+
+    return html_content
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=__name__)
+
+    parser.add_argument("before_dir", type=str, help="Directory containing screenshots before the incoming changes")
+    parser.add_argument("after_dir", type=str, help="Directory containing screenshots after the incoming changes")
+    parser.add_argument("output_dir", type=str, help="Directory to save the screenshots diff report")
+    parser.add_argument("incoming_changes_ref", type=str, help="Branch name or commit hash that contains the incoming changes")
+
+    parser.add_argument("--repository", default=None, help="owner/name of the repo the PR targets")
+    parser.add_argument("--pr-number", type=int, default=None)
+    parser.add_argument("--head-sha", default=None)
+    parser.add_argument("--base-ref", default=None)
+    parser.add_argument("--placeholder-report", default=None,
+                        help="path to the placeholder check's JSON output to embed")
+    parser.add_argument("--overflow-report", default=None,
+                        help="path to the overflow scan's JSON output to embed")
+    parser.add_argument("--note", action="append", default=None,
+                        help="note to append to the manifest, e.g. why rendering was skipped; repeatable")
+
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+
+    # `before_dir` includes the branch name we'll be merging into
+    baseline_branch = args.before_dir.split(os.path.sep)[-1]
+
+    diff = diff_screenshot_trees(args.before_dir, args.after_dir)
+    copy_screenshots(diff, args.before_dir, args.after_dir, args.output_dir)
+
+    notes = list(args.note or [])
+    manifest = build_manifest(diff, args, notes)
+    with open(os.path.join(args.output_dir, "manifest.json"), "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+    html_content = build_html(diff, baseline_branch, args.incoming_changes_ref)
+
+    script_dir = pathlib.Path(__file__).parent.resolve()
+    with open(os.path.join(script_dir, "index.html"), "r") as f:
+        html_output = f.read().replace("{{ content }}", html_content)
+
+    with open(os.path.join(args.output_dir, "index.html"), "w") as f:
+        f.write(html_output)
+
+    # Also copy the css file; source: https://github.com/picocss/pico
+    shutil.copy(os.path.join(script_dir, "pico.min.css"), os.path.join(args.output_dir, "pico.min.css"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/l10n/automation/tests/test_diff_screenshots.py
+++ b/l10n/automation/tests/test_diff_screenshots.py
@@ -1,0 +1,159 @@
+"""Tests for the screenshot diff / review-manifest producer."""
+
+import json
+import os
+import pathlib
+import sys
+
+# The script lives with the workflow assets, not in l10n/automation.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / ".github" / "diff_report"))
+
+import diff_screenshots  # noqa: E402
+
+
+def write_tree(root, files):
+    """files: {fragment: content} written under root."""
+    for fragment, content in files.items():
+        path = root / fragment.replace("/", os.path.sep)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    return str(root)
+
+
+def test_pathname_fragment_uses_forward_slashes(tmp_path):
+    path = os.path.sep.join(["artifacts", "dev", "de", "psbt_views", "SomeView.png"])
+    assert diff_screenshots.get_pathname_fragment(path) == "de/psbt_views/SomeView.png"
+
+
+def test_locale_and_screenshot_name():
+    assert diff_screenshots.get_locale_and_screenshot_name("de/psbt_views/SomeView.png") == \
+        ("de", "SomeView")
+
+
+def test_diff_buckets_added_removed_changed(tmp_path):
+    before = write_tree(tmp_path / "dev", {
+        "de/a/Same.png": b"same",
+        "de/a/Changed.png": b"old",
+        "de/a/Removed.png": b"gone",
+    })
+    after = write_tree(tmp_path / "incoming", {
+        "de/a/Same.png": b"same",
+        "de/a/Changed.png": b"new",
+        "de/a/Added.png": b"fresh",
+    })
+
+    diff = diff_screenshots.diff_screenshot_trees(before, after)
+
+    assert diff["added"] == ["de/a/Added.png"]
+    assert diff["removed"] == ["de/a/Removed.png"]
+    assert diff["changed"] == ["de/a/Changed.png"]
+    assert diff["counts"] == {"added": 1, "removed": 1, "changed": 1,
+                              "total_before": 3, "total_after": 3}
+
+
+def test_diff_lists_are_sorted_for_determinism(tmp_path):
+    before = write_tree(tmp_path / "dev", {})
+    after = write_tree(tmp_path / "incoming", {
+        "ja/b/Zeta.png": b"z", "de/a/Alpha.png": b"a", "de/z/Mid.png": b"m",
+    })
+
+    diff = diff_screenshots.diff_screenshot_trees(before, after)
+    assert diff["added"] == ["de/a/Alpha.png", "de/z/Mid.png", "ja/b/Zeta.png"]
+
+
+def test_copy_screenshots_places_before_and_after(tmp_path):
+    before = write_tree(tmp_path / "dev", {"de/a/Changed.png": b"old",
+                                           "de/a/Removed.png": b"gone"})
+    after = write_tree(tmp_path / "incoming", {"de/a/Changed.png": b"new",
+                                               "de/a/Added.png": b"fresh"})
+    out = tmp_path / "diff"
+
+    diff = diff_screenshots.diff_screenshot_trees(before, after)
+    diff_screenshots.copy_screenshots(diff, before, after, str(out))
+
+    assert (out / "before" / "de" / "a" / "Changed.png").read_bytes() == b"old"
+    assert (out / "after" / "de" / "a" / "Changed.png").read_bytes() == b"new"
+    assert (out / "before" / "de" / "a" / "Removed.png").exists()
+    assert (out / "after" / "de" / "a" / "Added.png").exists()
+    # Unchanged screenshots are not copied at all
+    assert not (out / "before" / "de" / "a" / "Added.png").exists()
+
+
+def test_cli_writes_manifest_and_html(tmp_path):
+    before = write_tree(tmp_path / "dev", {"de/a/Changed.png": b"old"})
+    after = write_tree(tmp_path / "incoming", {"de/a/Changed.png": b"new"})
+    out = tmp_path / "diff"
+    out.mkdir()
+
+    placeholder_report = tmp_path / "placeholder.json"
+    placeholder_report.write_text(json.dumps({"issues": [], "counts": {"issues": 0}}),
+                                  encoding="utf-8")
+
+    rc = diff_screenshots.main([
+        before, after, str(out), "my-branch",
+        "--repository", "owner/repo", "--pr-number", "12",
+        "--head-sha", "cafe123", "--base-ref", "dev",
+        "--placeholder-report", str(placeholder_report),
+    ])
+    assert rc == 0
+
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "1.0"
+    assert manifest["stream"] == "translation-review"
+    assert manifest["repository"] == "owner/repo"
+    assert manifest["pr"] == {"number": 12, "head_sha": "cafe123", "base_ref": "dev"}
+    assert manifest["screenshots"]["changed"] == ["de/a/Changed.png"]
+    assert manifest["checks"]["placeholder"] == {"issues": [], "counts": {"issues": 0}}
+    assert manifest["checks"]["overflow"] is None
+    assert manifest["notes"] == []
+
+    assert "de/a/Changed.png" in (out / "index.html").read_text(encoding="utf-8")
+    assert (out / "pico.min.css").exists()
+
+
+def test_cli_without_pr_args_leaves_manifest_fields_null(tmp_path):
+    before = write_tree(tmp_path / "dev", {"de/a/Same.png": b"same"})
+    after = write_tree(tmp_path / "incoming", {"de/a/Same.png": b"same"})
+    out = tmp_path / "diff"
+    out.mkdir()
+
+    assert diff_screenshots.main([before, after, str(out), "my-branch"]) == 0
+
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["repository"] is None
+    assert manifest["pr"] == {"number": None, "head_sha": None, "base_ref": None}
+    assert manifest["screenshots"]["counts"]["changed"] == 0
+
+
+def test_unreadable_check_report_becomes_a_note(tmp_path):
+    before = write_tree(tmp_path / "dev", {})
+    after = write_tree(tmp_path / "incoming", {})
+    out = tmp_path / "diff"
+    out.mkdir()
+
+    corrupt = tmp_path / "overflow.json"
+    corrupt.write_text("{ not json", encoding="utf-8")
+
+    assert diff_screenshots.main([
+        before, after, str(out), "ref", "--overflow-report", str(corrupt),
+    ]) == 0
+
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["checks"]["overflow"] is None
+    assert len(manifest["notes"]) == 1
+    assert "could not be read" in manifest["notes"][0]
+
+
+def test_notes_flag_lands_in_manifest(tmp_path):
+    before = write_tree(tmp_path / "dev", {})
+    after = write_tree(tmp_path / "incoming", {})
+    out = tmp_path / "diff"
+    out.mkdir()
+
+    assert diff_screenshots.main([
+        before, after, str(out), "ref",
+        "--note", "Rendering skipped: fix the placeholder issues first.",
+    ]) == 0
+
+    manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["notes"] == ["Rendering skipped: fix the placeholder issues first."]


### PR DESCRIPTION
> [!NOTE]
> One of the translation-review automation PRs (#96, #97, #98, #99, #100). This PR has no dependencies on the others, and the existing CI invocation keeps working unchanged.

## Description

### Problem

`diff_screenshots.py` produces a human-readable HTML diff of the before/after screenshot renders, but nothing machine-readable: downstream automation (a trusted follow-up job that comments on the PR and publishes a review page) needs a structured summary of what changed, bound to the PR it describes.

### Solution

Restructures `.github/diff_report/diff_screenshots.py` into functions and adds `manifest.json` to its output: the added/removed/changed screenshots keyed by the `<locale>/<section>/<name>.png` fragment (sorted, and always forward-slash separated, for determinism), exact counts, and optionally embedded check reports.

New optional args carry the PR coordinates (`--repository`, `--pr-number`, `--head-sha`, `--base-ref`) so a follow-up job can bind the manifest to its triggering run, embed check outputs (`--placeholder-report`, `--overflow-report`), and append explanatory notes (`--note`). All are optional: the existing positional interface, the `index.html` report and the before/after copies behave exactly as before, so the current `tests.yml` invocation is unaffected. Unreadable check reports become manifest notes rather than failures, so the manifest always states what it does not know.

This pull request is categorized as a:
- [x] Other (l10n automation)

## Checklist

- [x] I added tests.
- [x] I ran the tests locally: `python -m pytest l10n/automation/tests` (standalone; this repo has no main pytest suite).

