### PR TITLE
[l10n/automation] Publish the translation review: per-PR page and sticky comment

### DIFF
--- a/.github/workflows/l10n-translation-review-report.yml
+++ b/.github/workflows/l10n-translation-review-report.yml
@@ -1,0 +1,327 @@
+# Publishes the translation-review results: the per-PR visual review page and
+# one sticky status comment.
+#
+# This is the write-capable half of the review pair. It is triggered by the
+# read-only "l10n translation review" run completing, and runs code from the
+# default branch rather than the PR, so it never executes PR-supplied code.
+# The artifact it downloads is untrusted: the manifest is validated against
+# its schema and trust anchors, the PR-number<->head-SHA binding is confirmed
+# against the live PR, and only files the manifest lists (re-checked for path
+# allowlist, PNG magic and size) ever reach the published page, which is
+# static HTML with every string escaped.
+#
+# The page is deployed to a bot fork's gh-pages branch under /pr-<n>/ with a
+# GitHub App token scoped to that fork; this repo itself never carries a
+# contents:write credential. The comment uses the default token's
+# pull-requests:write. When a PR closes, its page directory is removed.
+#
+# No-op until the repo variable L10N_PAGES_FORK (e.g. "<bot>/seedsigner-
+# translations") and the L10N_PAGES_* App secrets are configured; see
+# l10n/automation/SETUP.md.
+name: l10n translation review report
+
+on:
+  workflow_run:
+    workflows: ["l10n translation review"]
+    types: [completed]
+  pull_request_target:
+    types: [closed]
+    paths:
+      - "l10n/**"
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    # Act on producer runs that came from a pull request, including failed
+    # ones: the blocking placeholder gate fails the producer after the
+    # artifact is uploaded, and that failure detail belongs in the comment.
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      contains(fromJSON('["success", "failure"]'), github.event.workflow_run.conclusion) &&
+      vars.L10N_PAGES_FORK != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    # All page deploys share one gh-pages branch; serialize them.
+    concurrency:
+      group: l10n-review-pages
+      cancel-in-progress: false
+    steps:
+      - name: Checkout default-branch automation code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Download review artifact
+        id: download
+        # A producer run that crashed before uploading has no artifact; that
+        # is a producer problem (its run is already red), so skip quietly.
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: translation-review
+          path: incoming
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check artifact presence
+        id: artifact
+        run: |
+          set -euo pipefail
+          if [ -f incoming/manifest.json ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No review artifact on this run; nothing to report."
+          fi
+
+      - name: Set up Python
+        if: steps.artifact.outputs.present == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install validation deps
+        if: steps.artifact.outputs.present == 'true'
+        # Only jsonschema is needed here; the page and comment builders are
+        # stdlib-only. This is the sole consumer, so it is pinned inline
+        # rather than in a requirements file.
+        run: python -m pip install --quiet "jsonschema==4.26.0"
+
+      - name: Validate manifest
+        if: steps.artifact.outputs.present == 'true'
+        env:
+          EXPECT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EXPECT_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python l10n/automation/validate_review_manifest.py \
+            --manifest incoming/manifest.json \
+            --schema l10n/automation/schema/translation-review-manifest.schema.json \
+            --expect-head-sha "$EXPECT_HEAD_SHA" \
+            --expect-repository "$EXPECT_REPO"
+
+      - name: Bind manifest to its pull request
+        id: bind
+        if: steps.artifact.outputs.present == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const manifest = JSON.parse(fs.readFileSync('incoming/manifest.json', 'utf8'));
+            const prNumber = manifest.pr.number;
+            const runHeadSha = process.env.RUN_HEAD_SHA;
+
+            // Authoritative PR-number <-> head-SHA binding: confirm the PR this
+            // manifest names really has the head commit the producing run was
+            // built from. Prevents a malicious PR from hijacking another PR's
+            // page slot or comment thread.
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            if (pr.head.sha !== runHeadSha) {
+              core.warning(
+                `PR #${prNumber} head ${pr.head.sha} != run head ${runHeadSha}; ` +
+                `skipping (PR advanced, or the manifest names someone else's PR).`);
+              core.setOutput('proceed', 'false');
+              return;
+            }
+            core.setOutput('proceed', 'true');
+            core.setOutput('pr_number', String(prNumber));
+            core.setOutput('pr_open', pr.state === 'open' ? 'true' : 'false');
+
+      - name: Build review page
+        if: steps.bind.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          python l10n/automation/build_review_page.py \
+            --manifest incoming/manifest.json \
+            --artifact-dir incoming \
+            --out page
+
+      - name: Prepare Pages fork coordinates
+        id: pages
+        if: steps.bind.outputs.proceed == 'true' && steps.bind.outputs.pr_open == 'true'
+        env:
+          PAGES_FORK: ${{ vars.L10N_PAGES_FORK }}
+        run: |
+          set -euo pipefail
+          echo "owner=${PAGES_FORK%%/*}" >> "$GITHUB_OUTPUT"
+          echo "repo=${PAGES_FORK##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Mint Pages fork token
+        id: pages_token
+        if: steps.bind.outputs.proceed == 'true' && steps.bind.outputs.pr_open == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.L10N_PAGES_CLIENT_ID }}
+          private-key: ${{ secrets.L10N_PAGES_PRIVATE_KEY }}
+          owner: ${{ steps.pages.outputs.owner }}
+          repositories: ${{ steps.pages.outputs.repo }}
+          permission-contents: write
+
+      - name: Deploy page to the bot fork
+        id: deploy
+        if: steps.bind.outputs.proceed == 'true' && steps.bind.outputs.pr_open == 'true'
+        env:
+          GH_TOKEN: ${{ steps.pages_token.outputs.token }}
+          APP_SLUG: ${{ steps.pages_token.outputs.app-slug }}
+          PAGES_FORK: ${{ vars.L10N_PAGES_FORK }}
+          PAGES_OWNER: ${{ steps.pages.outputs.owner }}
+          PAGES_REPO: ${{ steps.pages.outputs.repo }}
+          PR_NUMBER: ${{ steps.bind.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          url="https://x-access-token:${GH_TOKEN}@github.com/${PAGES_FORK}.git"
+          if ! git clone --quiet --depth 1 --branch gh-pages "$url" site 2>/dev/null; then
+            # First deploy ever: start an orphan gh-pages branch.
+            git init --quiet site
+            git -C site checkout --quiet --orphan gh-pages
+            git -C site remote add origin "$url"
+          fi
+
+          rm -rf "site/pr-${PR_NUMBER}"
+          mkdir -p "site/pr-${PR_NUMBER}"
+          cp -a page/. "site/pr-${PR_NUMBER}/"
+          touch site/.nojekyll
+
+          cd site
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Page unchanged; nothing to push."
+          else
+            git config user.name "${APP_SLUG}[bot]"
+            git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+            git commit --quiet -m "l10n: review page for PR #${PR_NUMBER}"
+            git push --quiet origin gh-pages
+          fi
+          echo "page_url=https://${PAGES_OWNER}.github.io/${PAGES_REPO}/pr-${PR_NUMBER}/" >> "$GITHUB_OUTPUT"
+
+      - name: Render comment
+        if: steps.bind.outputs.proceed == 'true'
+        env:
+          PAGE_URL: ${{ steps.deploy.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          python l10n/automation/render_review_comment.py \
+            --manifest incoming/manifest.json \
+            --page-url "$PAGE_URL" \
+            --out comment.md
+
+      - name: Upsert review comment
+        if: steps.bind.outputs.proceed == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.bind.outputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- l10n-automation:comment=translation-review -->';
+
+            const body = fs.readFileSync('comment.md', 'utf8');
+            const prNumber = Number(process.env.PR_NUMBER);
+
+            // The login this token comments as (e.g. "github-actions[bot]"); the
+            // [bot] suffix is normalized away so REST and GraphQL forms compare equal.
+            const { viewer } = await github.graphql('query { viewer { login } }');
+            const myLogin = viewer.login.replace(/\[bot\]$/, '');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            // Match our own previous comment: the marker identifies the stream,
+            // and requiring our exact author login means a human (or any other
+            // bot) carrying the marker can never be mistaken for the one we maintain.
+            const existing = comments.find(c =>
+              c.user && c.user.login.replace(/\[bot\]$/, '') === myLogin &&
+              c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated review comment ${existing.id} on PR #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+              core.info(`Created review comment on PR #${prNumber}.`);
+            }
+
+  cleanup:
+    # Remove the PR's page directory when it closes. pull_request_target runs
+    # in the base repo context so the App secrets are available; it is safe
+    # here because nothing from the PR is checked out or executed - the only
+    # PR-controlled input used is the PR number.
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      vars.L10N_PAGES_FORK != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}
+    concurrency:
+      group: l10n-review-pages
+      cancel-in-progress: false
+    steps:
+      - name: Prepare Pages fork coordinates
+        id: pages
+        env:
+          PAGES_FORK: ${{ vars.L10N_PAGES_FORK }}
+        run: |
+          set -euo pipefail
+          echo "owner=${PAGES_FORK%%/*}" >> "$GITHUB_OUTPUT"
+          echo "repo=${PAGES_FORK##*/}" >> "$GITHUB_OUTPUT"
+
+      - name: Mint Pages fork token
+        id: pages_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.L10N_PAGES_CLIENT_ID }}
+          private-key: ${{ secrets.L10N_PAGES_PRIVATE_KEY }}
+          owner: ${{ steps.pages.outputs.owner }}
+          repositories: ${{ steps.pages.outputs.repo }}
+          permission-contents: write
+
+      - name: Remove the PR's page
+        env:
+          GH_TOKEN: ${{ steps.pages_token.outputs.token }}
+          APP_SLUG: ${{ steps.pages_token.outputs.app-slug }}
+          PAGES_FORK: ${{ vars.L10N_PAGES_FORK }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          url="https://x-access-token:${GH_TOKEN}@github.com/${PAGES_FORK}.git"
+          if ! git clone --quiet --depth 1 --branch gh-pages "$url" site 2>/dev/null; then
+            echo "No gh-pages branch; nothing to clean up."
+            exit 0
+          fi
+          if [ ! -d "site/pr-${PR_NUMBER}" ]; then
+            echo "No page for PR #${PR_NUMBER}; nothing to clean up."
+            exit 0
+          fi
+          cd site
+          git rm -rq "pr-${PR_NUMBER}"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git commit --quiet -m "l10n: remove review page for closed PR #${PR_NUMBER}"
+          git push --quiet origin gh-pages

--- a/l10n/automation/build_review_page.py
+++ b/l10n/automation/build_review_page.py
@@ -1,0 +1,297 @@
+"""Assemble the static review page for a translation PR.
+
+Runs in the trusted report job on a schema-validated manifest, but the
+artifact files next to that manifest were produced by untrusted PR code, so
+nothing from the artifact is trusted by name or content:
+
+* only files the manifest lists are touched at all; nothing is globbed;
+* every path is re-checked against the fragment allowlist and confined to the
+  artifact directory (no symlinks, no traversal);
+* every file must carry the PNG magic bytes and respect a size cap;
+* every piece of text rendered into the page is HTML-escaped.
+
+A listed file that is missing or invalid rejects the whole artifact: the
+producer writes the manifest and the files together, so any mismatch means a
+bug or tampering, and serving a partial page would hide that.
+
+The output directory is self-contained (one index.html plus the copied PNGs,
+inline CSS, no scripts) and is deployed as-is under /pr-<n>/ on the review
+Pages site.
+
+Usage::
+
+    python l10n/automation/build_review_page.py \
+        --manifest incoming/manifest.json --artifact-dir incoming --out page
+"""
+
+import argparse
+import html
+import json
+import os
+import re
+import shutil
+import sys
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+MAX_PNG_BYTES = 5 * 1024 * 1024
+
+# Mirrors the manifest schema's fragment pattern; re-checked here so this
+# script does not silently depend on the schema validation having run.
+_FRAGMENT_RE = re.compile(
+    r"^[A-Za-z][A-Za-z0-9_]{0,19}/[a-z0-9_]{1,60}/[A-Za-z0-9_.-]{1,120}\.png$")
+_REPORT_RE = re.compile(
+    r"^reports/[A-Za-z][A-Za-z0-9_]{0,19}/[A-Za-z0-9_.-]{1,120}\.png$")
+
+_CSS = """
+body { font-family: system-ui, sans-serif; margin: 2rem auto; max-width: 70rem;
+       padding: 0 1rem; background: #111; color: #ddd; }
+h1, h2, h3 { color: #fff; }
+a { color: #f90; }
+table { border-collapse: collapse; margin: 1rem 0; }
+td, th { border: 1px solid #444; padding: 0.4rem 0.7rem; text-align: left; }
+code { background: #222; padding: 0.1rem 0.3rem; border-radius: 3px; }
+.pass { color: #6c6; } .fail { color: #e66; } .advisory { color: #ec3; }
+figure { display: inline-block; margin: 0.6rem; text-align: center; vertical-align: top; }
+figcaption { font-size: 0.8rem; color: #aaa; max-width: 500px;
+             overflow-wrap: break-word; }
+img { image-rendering: pixelated; border: 1px solid #444; max-width: 100%; }
+.pair img { width: 240px; }
+.note { color: #999; font-size: 0.9rem; }
+"""
+
+
+class ArtifactError(Exception):
+    """A manifest-listed file is missing or fails validation."""
+
+
+def _validated_source(artifact_dir: str, relpath: str, pattern: re.Pattern) -> str:
+    """Resolve a manifest-listed relative path inside the artifact dir,
+    enforcing the allowlist, containment, regular-file, magic and size rules.
+    """
+    if not pattern.fullmatch(relpath):
+        raise ArtifactError(f"path {relpath!r} does not match the allowlist")
+
+    root = os.path.realpath(artifact_dir)
+    path = os.path.realpath(os.path.join(root, relpath.replace("/", os.path.sep)))
+    if os.path.commonpath([root, path]) != root:
+        raise ArtifactError(f"path {relpath!r} escapes the artifact directory")
+
+    if os.path.islink(os.path.join(root, relpath.replace("/", os.path.sep))):
+        raise ArtifactError(f"{relpath!r} is a symlink")
+    if not os.path.isfile(path):
+        raise ArtifactError(f"manifest lists {relpath!r} but it is missing")
+
+    size = os.path.getsize(path)
+    if size > MAX_PNG_BYTES:
+        raise ArtifactError(f"{relpath!r} is {size} bytes; cap is {MAX_PNG_BYTES}")
+
+    with open(path, "rb") as fh:
+        if fh.read(len(PNG_MAGIC)) != PNG_MAGIC:
+            raise ArtifactError(f"{relpath!r} is not a PNG")
+
+    return path
+
+
+def collect_files(manifest: dict, artifact_dir: str) -> dict:
+    """Map every file the page needs (relpath -> validated source path).
+
+    Diff-listed screenshots are mandatory; an overflow composite is optional
+    because the scanner only writes one when the translated screenshot exists.
+    """
+    files = {}
+
+    screenshots = manifest["screenshots"]
+    for fragment in screenshots["removed"]:
+        rel = f"before/{fragment}"
+        files[rel] = _validated_source(artifact_dir, rel, re.compile(r"^before/" + _FRAGMENT_RE.pattern[1:]))
+    for fragment in screenshots["added"]:
+        rel = f"after/{fragment}"
+        files[rel] = _validated_source(artifact_dir, rel, re.compile(r"^after/" + _FRAGMENT_RE.pattern[1:]))
+    for fragment in screenshots["changed"]:
+        for side in ("before", "after"):
+            rel = f"{side}/{fragment}"
+            files[rel] = _validated_source(artifact_dir, rel, re.compile(f"^{side}/" + _FRAGMENT_RE.pattern[1:]))
+
+    overflow = (manifest.get("checks") or {}).get("overflow") or {}
+    for locale, events in overflow.items():
+        for event in events:
+            rel = f"reports/{locale}/{event['screen_name']}_overflow.png"
+            if rel in files:
+                continue
+            # A composite is optional: the scanner only writes one when the
+            # translated screenshot exists. But if present it must validate.
+            if not os.path.lexists(os.path.join(artifact_dir, rel.replace("/", os.path.sep))):
+                continue
+            files[rel] = _validated_source(artifact_dir, rel, _REPORT_RE)
+
+    return files
+
+
+def _esc(value) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def _placeholder_section(placeholder) -> list:
+    lines = ["<h2>Placeholder integrity (blocking)</h2>"]
+    if placeholder is None:
+        lines.append('<p class="note">Not run for this PR.</p>')
+        return lines
+
+    issues = placeholder["issues"]
+    checked = ", ".join(placeholder["checked_locales"]) or "none"
+    if not issues:
+        lines.append(f'<p class="pass">PASS: no placeholder issues '
+                     f'(locales checked: {_esc(checked)}).</p>')
+        return lines
+
+    lines.append(f'<p class="fail">FAIL: {len(issues)} issue(s) '
+                 f'(locales checked: {_esc(checked)}). A wrong placeholder '
+                 f'crashes or silently breaks the rendered text.</p>')
+    lines.append("<table><tr><th>Locale</th><th>Source string</th><th>Form</th>"
+                 "<th>Expected</th><th>Found</th></tr>")
+    for issue in issues[:50]:
+        found = "(does not parse)" if issue["found"] is None else " ".join(issue["found"])
+        fuzzy = " (fuzzy)" if issue.get("fuzzy") else ""
+        lines.append(
+            f"<tr><td>{_esc(issue['locale'])}</td>"
+            f"<td><code>{_esc(issue['msgid'])}</code></td>"
+            f"<td>{_esc(issue['form'])}{_esc(fuzzy)}</td>"
+            f"<td><code>{_esc(' '.join(issue['expected']))}</code></td>"
+            f"<td><code>{_esc(found)}</code></td></tr>")
+    lines.append("</table>")
+    if len(issues) > 50:
+        lines.append(f'<p class="note">...and {len(issues) - 50} more.</p>')
+    return lines
+
+
+def _overflow_section(overflow, files: dict) -> list:
+    lines = ["<h2>Text overflow (advisory)</h2>"]
+    if overflow is None:
+        lines.append('<p class="note">Not run for this PR.</p>')
+        return lines
+
+    total = sum(len(events) for events in overflow.values())
+    if total == 0:
+        lines.append('<p class="pass">No overflow detected in the scanned locales.</p>')
+        return lines
+
+    lines.append(f'<p class="advisory">{total} flagged component(s). Overflow is a '
+                 f'visual judgment call and has known false positives (untranslated '
+                 f'literals, screens that already overflow in English).</p>')
+    for locale in sorted(overflow):
+        events = overflow[locale]
+        if not events:
+            continue
+        lines.append(f"<h3>{_esc(locale)}</h3>")
+        for event in events:
+            composite = f"reports/{locale}/{event['screen_name']}_overflow.png"
+            lines.append("<figure>")
+            if composite in files:
+                lines.append(f'<img src="{_esc(composite)}" alt="{_esc(event["screen_name"])} overflow composite">')
+            lines.append(
+                f"<figcaption>[{_esc(event['event_type'])}] "
+                f"{_esc(event['screen_name'])}: {_esc(event['overflow_px'])}px"
+                + (f"<br><code>{_esc(event['msgstr'])}</code>" if event.get("msgstr") else "")
+                + "</figcaption></figure>")
+    return lines
+
+
+def _screenshots_section(screenshots: dict) -> list:
+    counts = screenshots["counts"]
+    lines = ["<h2>Screenshot changes</h2>"]
+    lines.append(
+        f"<p>{counts['changed']} changed, {counts['added']} added, "
+        f"{counts['removed']} removed (out of {counts['total_after']} rendered).</p>")
+
+    if not (screenshots["changed"] or screenshots["added"] or screenshots["removed"]):
+        lines.append('<p class="pass">No visual changes.</p>')
+        return lines
+
+    if screenshots["changed"]:
+        lines.append("<h3>Changed (before / after)</h3>")
+        for fragment in screenshots["changed"]:
+            lines.append(
+                f'<figure class="pair">'
+                f'<img src="{_esc("before/" + fragment)}" alt="before">'
+                f'<img src="{_esc("after/" + fragment)}" alt="after">'
+                f"<figcaption>{_esc(fragment)}</figcaption></figure>")
+
+    if screenshots["added"]:
+        lines.append("<h3>Added</h3>")
+        for fragment in screenshots["added"]:
+            lines.append(
+                f'<figure class="pair"><img src="{_esc("after/" + fragment)}" alt="added">'
+                f"<figcaption>{_esc(fragment)}</figcaption></figure>")
+
+    if screenshots["removed"]:
+        lines.append("<h3>Removed</h3>")
+        for fragment in screenshots["removed"]:
+            lines.append(
+                f'<figure class="pair"><img src="{_esc("before/" + fragment)}" alt="removed">'
+                f"<figcaption>{_esc(fragment)}</figcaption></figure>")
+
+    return lines
+
+
+def build_html(manifest: dict, files: dict) -> str:
+    pr = manifest["pr"]
+    lines = [
+        "<!DOCTYPE html>",
+        '<html lang="en"><head><meta charset="utf-8">',
+        f"<title>Translation review: PR #{_esc(pr['number'])}</title>",
+        f"<style>{_CSS}</style>",
+        "</head><body>",
+        f"<h1>Translation review: PR #{_esc(pr['number'])}</h1>",
+        f"<p>{_esc(manifest['repository'])} &middot; base <code>{_esc(pr['base_ref'])}</code> "
+        f"&middot; head <code>{_esc(pr['head_sha'][:10])}</code> "
+        f"&middot; generated {_esc(manifest['generated_at'])}</p>",
+    ]
+
+    checks = manifest["checks"]
+    lines += _placeholder_section(checks["placeholder"])
+    lines += _overflow_section(checks["overflow"], files)
+    lines += _screenshots_section(manifest["screenshots"])
+
+    for note in manifest.get("notes", []):
+        lines.append(f'<p class="note">Note: {_esc(note)}</p>')
+
+    lines.append('<p class="note">Static review page generated by the l10n '
+                 'automation; images only, no scripts.</p>')
+    lines.append("</body></html>")
+    return "\n".join(lines) + "\n"
+
+
+def build_page(manifest_path: str, artifact_dir: str, out_dir: str) -> int:
+    with open(manifest_path, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+
+    try:
+        files = collect_files(manifest, artifact_dir)
+    except ArtifactError as exc:
+        print(f"Artifact rejected: {exc}", file=sys.stderr)
+        return 1
+
+    os.makedirs(out_dir, exist_ok=True)
+    for rel, source in sorted(files.items()):
+        dest = os.path.join(out_dir, rel.replace("/", os.path.sep))
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copyfile(source, dest)
+
+    with open(os.path.join(out_dir, "index.html"), "w", encoding="utf-8") as fh:
+        fh.write(build_html(manifest, files))
+
+    print(f"Review page built: {len(files)} image(s) + index.html in {out_dir}")
+    return 0
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Build the static translation-review page.")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--artifact-dir", required=True)
+    p.add_argument("--out", required=True)
+    args = p.parse_args(argv)
+    return build_page(args.manifest, args.artifact_dir, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/render_review_comment.py
+++ b/l10n/automation/render_review_comment.py
@@ -1,0 +1,133 @@
+"""Render the sticky translation-review PR comment from a validated manifest.
+
+Runs in the trusted report job from default-branch code, but the manifest it
+consumes was produced by untrusted PR code, so every source or translated
+string is shown inside inline code spans with backticks stripped and newlines
+flattened, and never as raw markdown.
+
+The comment is one persistent status block per PR: blocking placeholder
+result, advisory overflow result, screenshot-diff counts, and the link to the
+visual review page when one was deployed.
+"""
+
+import argparse
+import html
+import json
+import sys
+from typing import List
+
+COMMENT_MARKER = "<!-- l10n-automation:comment=translation-review -->"
+
+_MAX_TEXT_CHARS = 120
+_MAX_LIST_ROWS = 10
+
+
+def _clean(text) -> str:
+    """Make untrusted text safe for an inline code span: flatten newlines,
+    strip backticks, bound the length."""
+    flat = str(text).replace("\r", " ").replace("\n", " ").replace("`", "'")
+    if len(flat) > _MAX_TEXT_CHARS:
+        flat = flat[:_MAX_TEXT_CHARS] + "..."
+    return flat
+
+
+def _placeholder_lines(placeholder) -> List[str]:
+    if placeholder is None:
+        return ["- Placeholder integrity: not run"]
+
+    issues = placeholder["issues"]
+    if not issues:
+        return ["- Placeholder integrity: **PASS**"]
+
+    lines = [f"- Placeholder integrity: **FAIL** ({len(issues)} issue(s)) - "
+             f"a wrong placeholder crashes or silently breaks the rendered text"]
+    for issue in issues[:_MAX_LIST_ROWS]:
+        found = "does not parse" if issue["found"] is None else " ".join(issue["found"])
+        expected = " ".join(issue["expected"])
+        lines.append(
+            f"  - `{issue['locale']}` `{_clean(issue['msgid'])}` "
+            f"({issue['form']}): expected `{_clean(expected)}`, found `{_clean(found)}`")
+    if len(issues) > _MAX_LIST_ROWS:
+        lines.append(f"  - ...and {len(issues) - _MAX_LIST_ROWS} more (see the review page)")
+    return lines
+
+
+def _overflow_lines(overflow) -> List[str]:
+    if overflow is None:
+        return ["- Text overflow: not run"]
+
+    total = sum(len(events) for events in overflow.values())
+    if total == 0:
+        return ["- Text overflow: none detected"]
+
+    per_locale = ", ".join(
+        f"{locale}: {len(events)}" for locale, events in sorted(overflow.items()) if events)
+    return [f"- Text overflow (advisory): {total} flagged component(s) ({per_locale}) - "
+            f"composites on the review page; known false positives exist"]
+
+
+def render(manifest: dict, page_url: str = "") -> str:
+    checks = manifest["checks"]
+    counts = manifest["screenshots"]["counts"]
+
+    lines = [COMMENT_MARKER, "## Translation review", ""]
+    lines += _placeholder_lines(checks["placeholder"])
+    lines += _overflow_lines(checks["overflow"])
+    lines.append(
+        f"- Screenshots: {counts['changed']} changed, {counts['added']} added, "
+        f"{counts['removed']} removed")
+
+    if page_url:
+        lines += ["", f"**[Open the visual review page]({page_url})** "
+                      f"(before/after screenshots and overflow composites)"]
+
+    for note in manifest.get("notes", []):
+        lines += ["", f"> **Note:** {html.escape(_clean(note))}"]
+
+    lines += [
+        "",
+        "<sub>The placeholder check is blocking; overflow and screenshot "
+        "changes are informational. This comment is updated in place on "
+        "every push.</sub>",
+    ]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def write_text(text: str, out: str) -> None:
+    """Write UTF-8 text to ``out``, or to stdout when ``out`` is ``-``.
+
+    The body embeds translated strings verbatim, so writing to stdout goes
+    through its binary buffer: a runner whose stdout encoding is ASCII would
+    otherwise raise UnicodeEncodeError on the first non-ASCII string. The
+    buffer is absent when stdout is substituted (captured in tests), in which
+    case the text layer already handles the encoding.
+    """
+    if out != "-":
+        with open(out, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return
+
+    buffer = getattr(sys.stdout, "buffer", None)
+    if buffer is None:
+        sys.stdout.write(text)
+    else:
+        buffer.write(text.encode("utf-8"))
+        buffer.flush()
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Render the review comment from a manifest.")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--page-url", default="")
+    p.add_argument("--out", default="-")
+    args = p.parse_args(argv)
+
+    with open(args.manifest, encoding="utf-8") as fh:
+        manifest = json.load(fh)
+
+    write_text(render(manifest, page_url=args.page_url), args.out)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/l10n/automation/schema/translation-review-manifest.schema.json
+++ b/l10n/automation/schema/translation-review-manifest.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/SeedSigner/seedsigner-translations/dev/l10n/automation/schema/translation-review-manifest.schema.json",
+  "title": "SeedSigner translation review manifest",
+  "description": "Summary of a translation PR's screenshot diff and check results, produced by the read-only review workflow and consumed by the trusted report workflow. The producing job runs untrusted PR code, so this manifest is treated as untrusted data: the consumer validates it against this schema and its trust anchors, and only touches artifact files whose names this manifest lists.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "stream",
+    "generated_at",
+    "repository",
+    "pr",
+    "screenshots",
+    "checks"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Manifest format version. Consumers must reject versions they do not understand.",
+      "const": "1.0"
+    },
+    "stream": {
+      "const": "translation-review"
+    },
+    "generated_at": {
+      "type": "string",
+      "maxLength": 40
+    },
+    "repository": {
+      "description": "owner/name of the repo the producing run executed in; must equal the consumer's own repository.",
+      "type": "string",
+      "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$",
+      "maxLength": 140
+    },
+    "pr": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["number", "head_sha", "base_ref"],
+      "properties": {
+        "number": { "type": "integer", "minimum": 1 },
+        "head_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "base_ref": { "type": "string", "minLength": 1, "maxLength": 200 }
+      }
+    },
+    "screenshots": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["added", "removed", "changed", "counts"],
+      "properties": {
+        "added": { "$ref": "#/$defs/fragmentList" },
+        "removed": { "$ref": "#/$defs/fragmentList" },
+        "changed": { "$ref": "#/$defs/fragmentList" },
+        "counts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["added", "removed", "changed", "total_before", "total_after"],
+          "properties": {
+            "added": { "$ref": "#/$defs/count" },
+            "removed": { "$ref": "#/$defs/count" },
+            "changed": { "$ref": "#/$defs/count" },
+            "total_before": { "$ref": "#/$defs/count" },
+            "total_after": { "$ref": "#/$defs/count" }
+          }
+        }
+      }
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["placeholder", "overflow"],
+      "properties": {
+        "placeholder": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["issues", "checked_locales", "counts"],
+              "properties": {
+                "issues": {
+                  "type": "array",
+                  "maxItems": 1000,
+                  "items": { "$ref": "#/$defs/placeholderIssue" }
+                },
+                "checked_locales": {
+                  "type": "array",
+                  "maxItems": 100,
+                  "items": { "$ref": "#/$defs/locale" }
+                },
+                "counts": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["issues", "locales_with_issues"],
+                  "properties": {
+                    "issues": { "$ref": "#/$defs/count" },
+                    "locales_with_issues": { "$ref": "#/$defs/count" }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "overflow": {
+          "description": "Overflow scan output: locale -> list of overflow events.",
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "maxProperties": 100,
+              "propertyNames": { "pattern": "^[A-Za-z][A-Za-z0-9_]{0,19}$" },
+              "additionalProperties": {
+                "type": "array",
+                "maxItems": 1000,
+                "items": { "$ref": "#/$defs/overflowEvent" }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "maxItems": 20,
+      "items": { "type": "string", "maxLength": 1000 }
+    }
+  },
+  "$defs": {
+    "count": { "type": "integer", "minimum": 0 },
+    "locale": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_]{0,19}$"
+    },
+    "fragment": {
+      "description": "Screenshot path fragment: <locale>/<section>/<ScreenshotName>.png. The character allowlist is what makes manifest-listed names safe to use as file paths.",
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_]{0,19}/[a-z0-9_]{1,60}/[A-Za-z0-9_.-]{1,120}\\.png$",
+      "maxLength": 200
+    },
+    "fragmentList": {
+      "type": "array",
+      "maxItems": 5000,
+      "items": { "$ref": "#/$defs/fragment" }
+    },
+    "placeholderIssue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["locale", "msgctxt", "msgid", "form", "problem", "expected", "found", "fuzzy"],
+      "properties": {
+        "locale": { "$ref": "#/$defs/locale" },
+        "msgctxt": {
+          "oneOf": [{ "type": "null" }, { "type": "string", "maxLength": 500 }]
+        },
+        "msgid": { "type": "string", "maxLength": 5000 },
+        "form": { "type": "string", "pattern": "^msgstr(\\[[0-9]{1,3}\\])?$" },
+        "problem": { "enum": ["mismatch", "malformed"] },
+        "expected": {
+          "type": "array",
+          "maxItems": 50,
+          "items": { "type": "string", "maxLength": 200 }
+        },
+        "found": {
+          "oneOf": [
+            { "type": "null" },
+            { "type": "array", "maxItems": 50, "items": { "type": "string", "maxLength": 200 } }
+          ]
+        },
+        "fuzzy": { "type": "boolean" }
+      }
+    },
+    "overflowEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["event_type", "screen_name", "locale", "component_text", "overflow_px",
+                   "component_type", "screen_y", "effective_height", "msgid", "msgstr"],
+      "properties": {
+        "event_type": { "enum": ["bounds", "collision"] },
+        "screen_name": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,120}$" },
+        "locale": { "$ref": "#/$defs/locale" },
+        "component_text": { "type": "string", "maxLength": 5000 },
+        "overflow_px": { "type": "integer", "minimum": 0, "maximum": 10000 },
+        "component_type": { "type": "string", "maxLength": 100 },
+        "screen_y": { "type": "integer", "minimum": -10000, "maximum": 10000 },
+        "effective_height": { "type": "integer", "minimum": 0, "maximum": 100000 },
+        "msgid": { "type": "string", "maxLength": 5000 },
+        "msgstr": { "type": "string", "maxLength": 5000 }
+      }
+    }
+  }
+}

--- a/l10n/automation/tests/test_build_review_page.py
+++ b/l10n/automation/tests/test_build_review_page.py
@@ -1,0 +1,179 @@
+"""Tests for the review-page builder (artifact file validation + static HTML)."""
+
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import build_review_page  # noqa: E402
+
+PNG = build_review_page.PNG_MAGIC + b"fakepixels"
+HEAD = "a" * 40
+
+
+def base_manifest(**over):
+    m = {
+        "schema_version": "1.0",
+        "stream": "translation-review",
+        "generated_at": "2026-07-21T00:00:00Z",
+        "repository": "owner/repo",
+        "pr": {"number": 7, "head_sha": HEAD, "base_ref": "dev"},
+        "screenshots": {
+            "added": [], "removed": [], "changed": [],
+            "counts": {"added": 0, "removed": 0, "changed": 0,
+                       "total_before": 0, "total_after": 0},
+        },
+        "checks": {"placeholder": None, "overflow": None},
+        "notes": [],
+    }
+    m.update(over)
+    return m
+
+
+def write_artifact(tmp_path, manifest, files):
+    incoming = tmp_path / "incoming"
+    incoming.mkdir(exist_ok=True)
+    (incoming / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    for rel, content in files.items():
+        path = incoming / rel.replace("/", os.path.sep)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    return incoming
+
+
+def build(tmp_path, manifest, files):
+    incoming = write_artifact(tmp_path, manifest, files)
+    out = tmp_path / "page"
+    rc = build_review_page.build_page(str(incoming / "manifest.json"), str(incoming), str(out))
+    return rc, out
+
+
+def changed_manifest(fragment="de/psbt_views/SomeView.png"):
+    return base_manifest(screenshots={
+        "added": [], "removed": [], "changed": [fragment],
+        "counts": {"added": 0, "removed": 0, "changed": 1,
+                   "total_before": 1, "total_after": 1},
+    })
+
+
+def test_happy_path_builds_page_with_copies(tmp_path):
+    fragment = "de/psbt_views/SomeView.png"
+    rc, out = build(tmp_path, changed_manifest(fragment), {
+        f"before/{fragment}": PNG, f"after/{fragment}": PNG + b"2",
+    })
+
+    assert rc == 0
+    assert (out / "before" / "de" / "psbt_views" / "SomeView.png").exists()
+    assert (out / "after" / "de" / "psbt_views" / "SomeView.png").exists()
+    html = (out / "index.html").read_text(encoding="utf-8")
+    assert "Translation review: PR #7" in html
+    assert f'src="before/{fragment}"' in html
+    assert "<script" not in html.lower().replace("</script", "")
+
+
+def test_missing_listed_file_rejects_artifact(tmp_path):
+    rc, out = build(tmp_path, changed_manifest(), {
+        "before/de/psbt_views/SomeView.png": PNG,
+        # after/ copy missing
+    })
+    assert rc == 1
+    assert not (out / "index.html").exists()
+
+
+def test_non_png_content_rejects_artifact(tmp_path):
+    fragment = "de/psbt_views/SomeView.png"
+    rc, _out = build(tmp_path, changed_manifest(fragment), {
+        f"before/{fragment}": PNG,
+        f"after/{fragment}": b"<html>not a png</html>",
+    })
+    assert rc == 1
+
+
+def test_oversize_file_rejects_artifact(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_review_page, "MAX_PNG_BYTES", 100)
+    fragment = "de/psbt_views/SomeView.png"
+    rc, _out = build(tmp_path, changed_manifest(fragment), {
+        f"before/{fragment}": PNG,
+        f"after/{fragment}": PNG + b"x" * 200,
+    })
+    assert rc == 1
+
+
+def test_symlink_rejects_artifact(tmp_path):
+    fragment = "de/psbt_views/SomeView.png"
+    incoming = write_artifact(tmp_path, changed_manifest(fragment), {
+        f"before/{fragment}": PNG,
+    })
+    target = tmp_path / "outside.png"
+    target.write_bytes(PNG)
+    link = incoming / "after" / "de" / "psbt_views" / "SomeView.png"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(target, link)
+
+    rc = build_review_page.build_page(
+        str(incoming / "manifest.json"), str(incoming), str(tmp_path / "page"))
+    assert rc == 1
+
+
+def test_bad_fragment_rejected_by_allowlist(tmp_path):
+    # Defense in depth: even if schema validation were skipped, the builder
+    # itself refuses fragments outside the allowlist.
+    manifest = changed_manifest("de/../../evil.png")
+    with pytest.raises(build_review_page.ArtifactError):
+        build_review_page.collect_files(manifest, str(tmp_path))
+
+
+def test_untrusted_text_is_escaped_into_the_page(tmp_path):
+    nasty = '<script>alert(1)</script><img src=x onerror=alert(1)>'
+    manifest = base_manifest(checks={
+        "placeholder": {
+            "issues": [{"locale": "de", "msgctxt": None, "msgid": nasty,
+                        "form": "msgstr", "problem": "mismatch",
+                        "expected": ["{x}"], "found": [nasty], "fuzzy": False}],
+            "checked_locales": ["de"],
+            "counts": {"issues": 1, "locales_with_issues": 1},
+        },
+        "overflow": None,
+    }, notes=[nasty])
+
+    rc, out = build(tmp_path, manifest, {})
+    assert rc == 0
+    html = (out / "index.html").read_text(encoding="utf-8")
+    assert "<script>alert(1)</script>" not in html
+    assert "&lt;script&gt;" in html
+
+
+def test_optional_composite_missing_is_fine_but_invalid_composite_rejects(tmp_path):
+    overflow = {"de": [{"event_type": "bounds", "screen_name": "SomeView",
+                        "locale": "de", "component_text": "t", "overflow_px": 9,
+                        "component_type": "TextArea", "screen_y": 100,
+                        "effective_height": 150, "msgid": "m", "msgstr": "s"}]}
+    manifest = base_manifest(checks={"placeholder": None, "overflow": overflow})
+
+    # Composite absent: page still builds, without the image
+    rc, out = build(tmp_path, manifest, {})
+    assert rc == 0
+    assert "reports/de/SomeView_overflow.png" not in \
+        (out / "index.html").read_text(encoding="utf-8")
+
+    # Composite present: copied and referenced
+    rc, out = build(tmp_path, manifest, {"reports/de/SomeView_overflow.png": PNG})
+    assert rc == 0
+    assert (out / "reports" / "de" / "SomeView_overflow.png").exists()
+    assert "reports/de/SomeView_overflow.png" in \
+        (out / "index.html").read_text(encoding="utf-8")
+
+    # Composite present but not a PNG: the whole artifact is rejected
+    rc, _out = build(tmp_path, manifest, {"reports/de/SomeView_overflow.png": b"nope"})
+    assert rc == 1
+
+
+def test_clean_manifest_builds_no_changes_page(tmp_path):
+    rc, out = build(tmp_path, base_manifest(), {})
+    assert rc == 0
+    html = (out / "index.html").read_text(encoding="utf-8")
+    assert "No visual changes" in html

--- a/l10n/automation/tests/test_render_review_comment.py
+++ b/l10n/automation/tests/test_render_review_comment.py
@@ -1,0 +1,123 @@
+"""Tests for the sticky review-comment renderer."""
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import render_review_comment  # noqa: E402
+
+
+def base_manifest(**over):
+    m = {
+        "schema_version": "1.0",
+        "stream": "translation-review",
+        "generated_at": "2026-07-21T00:00:00Z",
+        "repository": "owner/repo",
+        "pr": {"number": 7, "head_sha": "a" * 40, "base_ref": "dev"},
+        "screenshots": {
+            "added": [], "removed": [], "changed": [],
+            "counts": {"added": 0, "removed": 0, "changed": 0,
+                       "total_before": 0, "total_after": 0},
+        },
+        "checks": {"placeholder": None, "overflow": None},
+        "notes": [],
+    }
+    m.update(over)
+    return m
+
+
+def placeholder_report(issues):
+    return {
+        "issues": issues,
+        "checked_locales": sorted({i["locale"] for i in issues}) or ["de"],
+        "counts": {"issues": len(issues),
+                   "locales_with_issues": len({i["locale"] for i in issues})},
+    }
+
+
+def issue(**over):
+    base = {"locale": "no", "msgctxt": None, "msgid": "Enter {name}",
+            "form": "msgstr", "problem": "mismatch",
+            "expected": ["{name}"], "found": ["{}"], "fuzzy": False}
+    base.update(over)
+    return base
+
+
+def test_marker_and_counts():
+    body = render_review_comment.render(base_manifest())
+    assert render_review_comment.COMMENT_MARKER in body
+    assert "0 changed, 0 added, 0 removed" in body
+    assert "not run" in body
+
+
+def test_placeholder_pass_and_overflow_clean():
+    m = base_manifest(checks={"placeholder": placeholder_report([]),
+                              "overflow": {"de": []}})
+    body = render_review_comment.render(m)
+    assert "Placeholder integrity: **PASS**" in body
+    assert "Text overflow: none detected" in body
+
+
+def test_placeholder_failure_lists_issues():
+    m = base_manifest(checks={"placeholder": placeholder_report([issue()]),
+                              "overflow": None})
+    body = render_review_comment.render(m)
+    assert "**FAIL** (1 issue(s))" in body
+    assert "`no` `Enter {name}` (msgstr): expected `{name}`, found `{}`" in body
+
+
+def test_placeholder_failure_list_is_capped():
+    issues = [issue(msgid=f"String {i} with {{x}}") for i in range(15)]
+    m = base_manifest(checks={"placeholder": placeholder_report(issues),
+                              "overflow": None})
+    body = render_review_comment.render(m)
+    assert "...and 5 more" in body
+
+
+def test_overflow_summary_per_locale():
+    event = {"event_type": "bounds", "screen_name": "SomeView", "locale": "de",
+             "component_text": "t", "overflow_px": 9, "component_type": "TextArea",
+             "screen_y": 100, "effective_height": 150, "msgid": "m", "msgstr": "s"}
+    m = base_manifest(checks={"placeholder": None,
+                              "overflow": {"de": [event], "ja": [event, event]}})
+    body = render_review_comment.render(m)
+    assert "3 flagged component(s) (de: 1, ja: 2)" in body
+    assert "advisory" in body
+
+
+def test_page_url_link_included_only_when_given():
+    m = base_manifest()
+    body = render_review_comment.render(m, page_url="https://bot.github.io/x/pr-7/")
+    assert "[Open the visual review page](https://bot.github.io/x/pr-7/)" in body
+
+    assert "Open the visual review page" not in render_review_comment.render(m)
+
+
+def test_untrusted_text_cannot_break_out():
+    nasty = "evil`\n\n## pwned heading\n- nope"
+    m = base_manifest(checks={
+        "placeholder": placeholder_report([issue(msgid=nasty)]),
+        "overflow": None,
+    }, notes=[nasty])
+    body = render_review_comment.render(m)
+    for line in body.splitlines():
+        assert not line.startswith("## pwned")
+    assert "evil'" in body  # backticks stripped from code spans
+
+
+def test_cli_writes_output(tmp_path, capsysbinary):
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(base_manifest()), encoding="utf-8")
+    out = tmp_path / "comment.md"
+
+    rc = render_review_comment.main([
+        "--manifest", str(manifest_path), "--page-url", "https://x/pr-7/",
+        "--out", str(out)])
+    assert rc == 0
+    assert "https://x/pr-7/" in out.read_text(encoding="utf-8")
+
+    rc = render_review_comment.main(["--manifest", str(manifest_path), "--out", "-"])
+    assert rc == 0
+    assert render_review_comment.COMMENT_MARKER.encode() in capsysbinary.readouterr().out

--- a/l10n/automation/tests/test_validate_review_manifest.py
+++ b/l10n/automation/tests/test_validate_review_manifest.py
@@ -1,0 +1,143 @@
+"""Tests for the translation-review manifest validation (schema + trust anchors)."""
+
+import json
+import os
+import pathlib
+import sys
+
+import pytest
+
+pytest.importorskip("jsonschema")
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+import validate_review_manifest  # noqa: E402
+
+SCHEMA = os.path.join(os.path.dirname(__file__), "..", "schema",
+                      "translation-review-manifest.schema.json")
+HEAD = "a" * 40
+REPO = "owner/repo"
+
+EMPTY_DIFF = {
+    "added": [], "removed": [], "changed": [],
+    "counts": {"added": 0, "removed": 0, "changed": 0,
+               "total_before": 0, "total_after": 0},
+}
+
+
+def valid_manifest(**over):
+    m = {
+        "schema_version": "1.0",
+        "stream": "translation-review",
+        "generated_at": "2026-07-21T00:00:00Z",
+        "repository": REPO,
+        "pr": {"number": 7, "head_sha": HEAD, "base_ref": "dev"},
+        "screenshots": dict(EMPTY_DIFF),
+        "checks": {"placeholder": None, "overflow": None},
+        "notes": [],
+    }
+    m.update(over)
+    return m
+
+
+def run(tmp_path, manifest, *, head=HEAD, repo=REPO):
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps(manifest), encoding="utf-8")
+    return validate_review_manifest.validate(str(p), SCHEMA, head, repo)
+
+
+def test_valid_manifest_has_no_errors(tmp_path):
+    assert run(tmp_path, valid_manifest()) == []
+
+
+def test_populated_manifest_validates(tmp_path):
+    m = valid_manifest(
+        screenshots={
+            "added": ["no/seed_views/NewView.png"],
+            "removed": [],
+            "changed": ["zh_Hans_CN/psbt_views/SomeView.png"],
+            "counts": {"added": 1, "removed": 0, "changed": 1,
+                       "total_before": 150, "total_after": 151},
+        },
+        checks={
+            "placeholder": {
+                "issues": [{"locale": "no", "msgctxt": None, "msgid": "x {y}",
+                            "form": "msgstr", "problem": "mismatch",
+                            "expected": ["{y}"], "found": ["{}"], "fuzzy": False}],
+                "checked_locales": ["no"],
+                "counts": {"issues": 1, "locales_with_issues": 1},
+            },
+            "overflow": {
+                "no": [{"event_type": "bounds", "screen_name": "SomeView",
+                        "locale": "no", "component_text": "t", "overflow_px": 9,
+                        "component_type": "TextArea", "screen_y": 100,
+                        "effective_height": 150, "msgid": "m", "msgstr": "s"}],
+            },
+        })
+    assert run(tmp_path, m) == []
+
+
+def test_wrong_repository_rejected(tmp_path):
+    errors = run(tmp_path, valid_manifest(), repo="someone/else")
+    assert any("repository" in e for e in errors)
+
+
+def test_wrong_head_sha_rejected(tmp_path):
+    errors = run(tmp_path, valid_manifest(), head="b" * 40)
+    assert any("head_sha" in e for e in errors)
+
+
+def test_null_pr_fields_rejected(tmp_path):
+    # Push-run manifests carry nulls; the consumer only acts on PR manifests,
+    # and the schema must refuse anything without real PR coordinates.
+    m = valid_manifest(pr={"number": None, "head_sha": None, "base_ref": None})
+    errors = run(tmp_path, m, head="None")
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_traversal_fragment_rejected(tmp_path):
+    # The fragment allowlist is what makes manifest-listed names safe to use
+    # as file paths downstream.
+    for nasty in ["../../etc/passwd.png", "de/../x/y.png", "de/a/e.html",
+                  "de/a/x.png/", "/abs/a/x.png"]:
+        m = valid_manifest(screenshots=dict(EMPTY_DIFF, added=[nasty]))
+        errors = run(tmp_path, m)
+        assert any(e.startswith("schema:") for e in errors), nasty
+
+
+def test_unknown_top_level_field_rejected(tmp_path):
+    errors = run(tmp_path, valid_manifest(extra="nope"))
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_bad_overflow_locale_key_rejected(tmp_path):
+    m = valid_manifest(checks={"placeholder": None, "overflow": {"../..": []}})
+    errors = run(tmp_path, m)
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_wrong_stream_rejected(tmp_path):
+    errors = run(tmp_path, valid_manifest(stream="messages-pot"))
+    assert any(e.startswith("schema:") for e in errors)
+
+
+def test_missing_manifest_is_a_clean_error(tmp_path):
+    errors = validate_review_manifest.validate(
+        str(tmp_path / "nope.json"), SCHEMA, HEAD, REPO)
+    assert any(e.startswith("manifest: cannot read") for e in errors)
+
+
+def test_malformed_manifest_is_a_clean_error(tmp_path):
+    p = tmp_path / "manifest.json"
+    p.write_text("{ not json", encoding="utf-8")
+    errors = validate_review_manifest.validate(str(p), SCHEMA, HEAD, REPO)
+    assert any("is not valid JSON" in e for e in errors)
+
+
+def test_non_object_manifest_is_rejected(tmp_path):
+    # Valid JSON, but not an object: must never validate clean.
+    for payload in ("null", "[]", '"nope"'):
+        p = tmp_path / "manifest.json"
+        p.write_text(payload, encoding="utf-8")
+        errors = validate_review_manifest.validate(str(p), SCHEMA, HEAD, REPO)
+        assert f"manifest: {str(p)!r} is not a JSON object" in errors

--- a/l10n/automation/validate_review_manifest.py
+++ b/l10n/automation/validate_review_manifest.py
@@ -1,0 +1,94 @@
+"""Validate a translation-review manifest before the trusted job acts on it.
+
+The manifest was produced by untrusted PR code, so the trusted report job
+validates it against the JSON Schema and checks two trust anchors that GitHub
+sets authoritatively:
+
+* ``--expect-repository`` must equal ``manifest.repository``
+* ``--expect-head-sha`` (the triggering workflow_run head SHA) must equal
+  ``manifest.pr.head_sha``
+
+The PR-number<->head-SHA binding is completed in the workflow by fetching the
+PR and confirming its head SHA matches too; this script covers the data layer.
+The schema also constrains every screenshot path fragment to a strict
+character allowlist, which is what makes manifest-listed names safe to use as
+file paths later.
+"""
+
+import argparse
+import json
+import sys
+
+
+def _load_json_object(path: str, label: str, errors: list):
+    """Read a JSON object from a file, reporting failures as errors.
+
+    The manifest is attacker-influenced (produced by untrusted PR code) and may
+    be absent, empty or malformed, which must read as a clean rejection in the
+    CI log rather than an unhandled traceback. Returning ``None`` always comes
+    with an appended error, so a bare ``null`` payload cannot pass as valid.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except OSError as exc:
+        errors.append(f"{label}: cannot read {path!r}: {exc}")
+        return None
+    except json.JSONDecodeError as exc:
+        errors.append(f"{label}: {path!r} is not valid JSON: {exc}")
+        return None
+
+    if not isinstance(data, dict):
+        errors.append(f"{label}: {path!r} is not a JSON object")
+        return None
+    return data
+
+
+def validate(manifest_path: str, schema_path: str, expect_head_sha: str,
+             expect_repository: str) -> list:
+    import jsonschema
+
+    errors = []
+    manifest = _load_json_object(manifest_path, "manifest", errors)
+    schema = _load_json_object(schema_path, "schema", errors)
+    if manifest is None or schema is None:
+        return errors
+
+    validator = jsonschema.Draft202012Validator(schema)
+    # Sort on the stringified path: error paths mix str (object keys) and int
+    # (array indices), which are not orderable against each other directly.
+    for err in sorted(validator.iter_errors(manifest), key=lambda e: list(map(str, e.path))):
+        errors.append(f"schema: {'/'.join(map(str, err.path)) or '<root>'}: {err.message}")
+
+    head = manifest.get("pr", {}).get("head_sha") if isinstance(manifest.get("pr"), dict) else None
+    if head != expect_head_sha:
+        errors.append(f"pr.head_sha {head!r} != triggering run head {expect_head_sha!r}")
+
+    repo = manifest.get("repository")
+    if repo != expect_repository:
+        errors.append(f"repository {repo!r} != running repository {expect_repository!r}")
+
+    return errors
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description="Validate a translation-review manifest.")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--schema", required=True)
+    p.add_argument("--expect-head-sha", required=True)
+    p.add_argument("--expect-repository", required=True)
+    args = p.parse_args(argv)
+
+    errors = validate(args.manifest, args.schema, args.expect_head_sha,
+                      args.expect_repository)
+    if errors:
+        print("Manifest rejected:", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print("Manifest OK")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
> [!NOTE]
> One of the translation-review automation PRs (#96, #97, #98, #99, #100). Consumes the artifact produced by the review workflow (#98). No-ops until the repo variable `L10N_PAGES_FORK` and the `L10N_PAGES_*` App secrets are configured (see #100), so merging it changes nothing until a maintainer opts in.

## Description

### Problem

The review workflow's output is an artifact zip: useful, but reviewers and translators should not have to download and unpack artifacts. The results belong on the PR itself (one status comment) and on a browsable page (before/after screenshots, overflow composites) - published without ever granting this repository's automation `contents: write` anywhere upstream.

### Solution

Adds the write-capable half of the review pair:

- `schema/translation-review-manifest.schema.json` - strict contract for the producer's manifest (`additionalProperties: false`, bounded lengths, and a character allowlist on every screenshot path fragment, which is what makes manifest-listed names safe to use as file paths).
- `validate_review_manifest.py` - schema validation plus two trust anchors GitHub sets authoritatively: `manifest.repository` must equal this repo and `manifest.pr.head_sha` must equal the triggering run's head SHA.
- `build_review_page.py` - builds the static review page. Only files the manifest lists are touched (nothing is globbed), each re-checked for the path allowlist, containment in the artifact dir, no symlinks, PNG magic bytes and a size cap; one bad file rejects the whole artifact. The page is static HTML with every string escaped: images only, no scripts.
- `render_review_comment.py` - the sticky status comment: blocking placeholder result, advisory overflow summary, screenshot-diff counts, and the page link. Untrusted text is flattened into inline code spans.
- `.github/workflows/l10n-translation-review-report.yml` - triggered by the review run completing (including failed runs: the placeholder gate fails the producer after the artifact is uploaded, and that detail belongs in the comment). It runs default-branch code only, validates everything above, reconfirms the PR-number-to-head-SHA binding against the live PR (so a malicious PR cannot hijack another PR's page slot or comment thread), deploys the page to a bot fork's `gh-pages` under `/pr-<n>/` using a GitHub App token scoped to that fork, and upserts one comment using the default token's `pull-requests: write`. A `pull_request_target` cleanup job removes the page when the PR closes; it executes nothing from the PR and uses only the PR number.

This repository never carries a `contents: write` credential; branch writes happen only on the bot fork.

This pull request is categorized as a:
- [x] Other (l10n automation)

## Checklist

- [x] I added tests (schema/anchor validation, traversal/symlink/magic/size rejection, HTML and markdown escaping, comment rendering).
- [x] I ran the tests locally: `python -m pytest l10n/automation/tests` (standalone; this repo has no main pytest suite).
- [x] Tested hands-on: Github Actions, end to end on a test stand-in. The sticky comment (PASS and FAIL states, updated in place), the page deploy to the bot fork's `gh-pages`, and the close/reopen cleanup cycle are all visible on the test PR: https://github.com/Chaitanya-Keyal/seedsigner-translations/pull/5 (live page: https://okaybro-bot.github.io/seedsigner-translations/pr-5/)